### PR TITLE
Add implementation code and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,27 @@
+name = "MLJMultivariateStatsInterface"
+uuid = "1b6a4a23-ba22-4f51-9698-8599985d3728"
+
+[deps]
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
+MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[compat]
+Distances = "0.9"
+MLJModelInterface = "0.3.5"
+MultivariateStats = "0.7"
+StatsBase = "0.32, 0.33"
+julia = "1"
+
+[extras]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
+MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Dates", "MLJBase", "MultivariateStats", "Random", "StableRNGs", "Test"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# MLJMultivariateStatsInterface.jl
+# MLJ <> MultivariateStats.jl
+Repository implementing MLJ interface for 
+[MultivariateStats](https://github.com/JuliaStats/MultivariateStats.jl) models.
+
+
+[![Build Status](https://travis-ci.com/alan-turing-institute/MultivariateStatsInterface.jl.svg?branch=master)](https://travis-ci.com/github/alan-turing-institute/MLJMultivariateStatsInterface.jl)
+[![Coverage](https://coveralls.io/repos/github/alan-turing-institute/MLJMultivariateStatsInterface.jl/badge.svg?branch=master)](http://codecov.io/github/alan-turing-institute/MLJBase.jl?branch=master)
+[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)

--- a/src/MLJMultivariateStatsInterface.jl
+++ b/src/MLJMultivariateStatsInterface.jl
@@ -1,0 +1,129 @@
+module MLJMultivariateStatsInterface
+
+# ===================================================================
+# IMPORTS
+import MLJModelInterface
+import MLJModelInterface: Table, Continuous, Finite, @mlj_model, metadata_pkg,
+    metadata_model
+import MultivariateStats
+import MultivariateStats: SimpleCovariance
+import StatsBase: CovarianceEstimator
+
+using Distances
+using LinearAlgebra
+
+# ===================================================================
+## EXPORTS
+export LinearRegressor, RidgeRegressor, PCA, KernelPCA, ICA, PPCA, FactorAnalysis, LDA,
+    BayesianLDA, SubspaceLDA, BayesianSubspaceLDA
+
+# ===================================================================
+## Re-EXPORTS    
+export SimpleCovariance, CovarianceEstimator, SqEuclidean, CosineDist
+
+# ===================================================================
+## CONSTANTS
+# Define constants for easy referencing of packages
+const MMI = MLJModelInterface
+const MS = MultivariateStats
+const PCAFitResultType = MS.PCA
+const KernelPCAFitResultType = MS.KernelPCA
+const ICAFitResultType = MS.ICA
+const PPCAFitResultType = MS.PPCA
+const FactorAnalysisResultType = MS.FactorAnalysis
+const default_kernel = (x, y) -> x'y #default kernel used in KernelPCA
+
+# Definitions of model descriptions for use in model doc-strings.
+const PCA_DESCR = """Principal component analysis. Learns a linear transformation to 
+project the data  on a lower dimensional space while preserving most of the initial 
+variance.
+"""
+const KPCA_DESCR = "Kernel principal component analysis."
+const ICA_DESCR = "Independent component analysis."
+const PPCA_DESCR = "Probabilistic principal component analysis"
+const FactorAnalysis_DESCR = "Factor Analysis"
+const LDA_DESCR = """Multiclass linear discriminant analysis. The algorithm learns a 
+projection matrix `P` that projects a feature matrix `Xtrain` onto a lower dimensional  
+space of dimension `out_dim` such that the trace of the transformed between-class scatter 
+matrix(`Pᵀ*Sb*P`) is maximized relative to the trace of the transformed within-class 
+scatter matrix (`Pᵀ*Sw*P`).The projection matrix is scaled such that `Pᵀ*Sw*P=I` or 
+`Pᵀ*Σw*P=I`(where `Σw` is the within-class covariance matrix) .
+Predicted class posterior probability for feature matrix `Xtest` are derived by applying  
+a softmax transformationto a matrix `Pr`, such that  rowᵢ of `Pr` contains computed 
+distances(based on a distance metric) in the transformed space of rowᵢ in `Xtest` to the 
+centroid of each class.
+"""
+const BayesianLDA_DESCR = """Bayesian Multiclass linear discriminant analysis. The algorithm 
+learns a projection matrix `P` that projects a feature matrix `Xtrain` onto a lower 
+dimensional space of dimension `out_dim` such that the trace of the transformed 
+between-class scatter matrix(`Pᵀ*Sb*P`) is maximized relative to the trace of the 
+transformed within-class scatter matrix (`Pᵀ*Sw*P`). The projection matrix is scaled such 
+that `Pᵀ*Sw*P = n` or `Pᵀ*Σw*P=I` (Where `n` is the number of training samples and `Σw` 
+is the within-class covariance matrix).
+Predicted class posterior probability distibution are derived by applying Bayes rule with 
+a multivariate Gaussian class-conditional distribution.
+"""
+const SubspaceLDA_DESCR = """Multiclass linear discriminant analysis. Suitable for high 
+dimensional data (Avoids computing scatter matrices `Sw` ,`Sb`). The algorithm learns a 
+projection matrix `P = W*L` that projects a feature matrix `Xtrain` onto a lower 
+dimensional space of dimension `nc - 1` such that the trace of the transformed 
+between-class scatter matrix(`Pᵀ*Sb*P`) is maximized relative to the trace of the 
+transformed within-class scatter matrix (`Pᵀ*Sw*P`). The projection matrix is scaled such 
+that `Pᵀ*Sw*P = mult*I` or `Pᵀ*Σw*P=mult/(n-nc)*I` (where `n` is the number of training 
+samples, mult` is  one of `n` or `1` depending on whether `Sb` is normalized, `Σw` is the 
+within-class covariance matrix, and `nc` is the number of unique classes in `y`) and also 
+obeys `Wᵀ*Sb*p = λ*Wᵀ*Sw*p`, for every column `p` in `P`.
+Predicted class posterior probability for feature matrix `Xtest` are derived by applying a 
+softmax transformation to a matrix `Pr`, such that  rowᵢ of `Pr` contains computed 
+distances(based on a distance metric) in the transformed space of rowᵢ in `Xtest` to the 
+centroid of each class.
+"""
+const BayesianSubspaceLDA_DESCR = """Bayesian Multiclass linear discriminant analysis. 
+Suitable for high dimensional data (Avoids computing scatter matrices `Sw` ,`Sb`). The 
+algorithm learns a projection matrix `P = W*L` (`Sw`), that projects a feature matrix 
+`Xtrain` onto a lower dimensional space of dimension `nc-1` such that the trace of the 
+transformed between-class scatter matrix(`Pᵀ*Sb*P`) is maximized relative to the trace 
+of the transformed within-class scatter matrix (`Pᵀ*Sw*P`). The projection matrix is 
+scaled such that `Pᵀ*Sw*P = mult*I` or `Pᵀ*Σw*P=mult/(n-nc)*I` (where `n` is the number of 
+training samples, `mult` is  one of `n` or `1` depending on whether `Sb` is normalized, 
+`Σw` is the within-class covariance matrix, and `nc` is the number of unique classes in 
+`y`) and also obeys `Wᵀ*Sb*p = λ*Wᵀ*Sw*p`, for every column `p` in `P`.
+Posterior class probability distibution are derived by applying Bayes rule with a 
+multivariate Gaussian class-conditional distribution
+"""
+const LINEAR_DESCR = """Linear regression. Learns a linear combination(s) of given 
+variables to fit the responses by minimizing the squared error between.
+"""
+const RIDGE_DESCR = """Ridge regressor with regularization parameter lambda. Learns a 
+linear regression with a penalty on the l2 norm of the coefficients.
+"""
+
+const PKG = "MLJMultivariateStatsInterface"
+
+# ===================================================================
+# Includes
+include("models/decompostion_models.jl")
+include("models/discriminant_analysis.jl")
+include("models/linear_models.jl")
+include("utils.jl")
+
+# ===================================================================
+# List of all models interfaced
+const MODELS = (
+    RidgeRegressor, PCA, KernelPCA, ICA, LDA, BayesianLDA, SubspaceLDA,
+    BayesianSubspaceLDA
+)
+
+# ====================================================================
+# PKG_METADATA
+metadata_pkg.(
+    MODELS,
+    name = "MultivariateStats",
+    uuid = "6f286f6a-111f-5878-ab1e-185364afe411",
+    url = "https://github.com/JuliaStats/MultivariateStats.jl",
+    license = "MIT",
+    julia = true,
+    is_wrapper = false
+)
+
+end

--- a/src/models/decompostion_models.jl
+++ b/src/models/decompostion_models.jl
@@ -1,0 +1,382 @@
+####
+#### PCA
+####
+
+"""
+    PCA(; kwargs...)
+
+$PCA_DESCR
+
+# Keyword Parameters
+
+- `maxoutdim::Int=0`: maximum number of output dimensions, uses the smallest dimension of 
+    training feature matrix if 0 (default).
+- `method::Symbol=:auto`: method to use to solve the problem, one of `:auto`,`:cov` 
+    or `:svd`
+- `pratio::Float64=0.99`: ratio of variance preserved
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: if set to nothing(default)  
+    centering will be computed and applied, if set to `0` no 
+    centering(assumed pre-centered), if a vector is passed, the centering is done with 
+    that vector.
+"""
+@mlj_model mutable struct PCA <: MMI.Unsupervised
+    maxoutdim::Int = 0::(_ ≥ 0)
+    method::Symbol = :auto::(_ in (:auto, :cov, :svd))
+    pratio::Float64 = 0.99::(0.0 < _ ≤ 1.0)
+    mean::Union{Nothing, Real, Vector{Float64}} = nothing::(_check_typeof_mean(_))
+end
+
+function _check_typeof_mean(x)
+    return x isa Vector{<:Real} || x === nothing || (x isa Real && iszero(x))
+end
+
+function MMI.fit(model::PCA, verbosity::Int, X)
+    Xarray = MMI.matrix(X)
+    mindim = minimum(size(Xarray))
+    maxoutdim = model.maxoutdim == 0 ? mindim : model.maxoutdim
+    # NOTE: copy/transpose
+    fitresult = MS.fit(
+        MS.PCA, transpose(Xarray);
+        method=model.method,
+        pratio=model.pratio,
+        maxoutdim=maxoutdim,
+        mean=model.mean
+    )
+    cache = nothing
+    report = (
+        indim=MS.indim(fitresult),
+        outdim=MS.outdim(fitresult),
+        tprincipalvar=MS.tprincipalvar(fitresult),
+        tresidualvar=MS.tresidualvar(fitresult),
+        tvar=MS.tvar(fitresult),
+        mean=copy(MS.mean(fitresult)),
+        principalvars=copy(MS.principalvars(fitresult))
+    )
+    return fitresult, cache, report
+end
+
+function MMI.fitted_params(::PCA, fr)
+    return (projection=copy(MS.projection(fr)),)
+end
+
+function MMI.transform(::PCA, fr::PCAFitResultType, X)
+    # X is n x d, need to transpose twice...
+    Xarray = MMI.matrix(X)
+    Xnew = transpose(MS.transform(fr, transpose(Xarray)))
+    return MMI.table(Xnew, prototype=X)
+end
+
+metadata_model(PCA,
+    input=Table(Continuous),
+    output=Table(Continuous),
+    weights=false,
+    descr=PCA_DESCR,
+    path="$(PKG).PCA"
+)
+
+####
+#### KernelPCA
+####
+
+"""
+    KernelPCA(; kwargs...)
+
+$KPCA_DESCR
+
+# Keyword Parameters
+
+- `maxoutdim::Int = 0`: maximum number of output dimensions, uses the smallest 
+    dimension of training feature matrix if 0 (default).
+- `kernel::Function=(x,y)->x'y`: kernel function of 2 vector arguments x and y, returns a 
+    scalar value
+- `solver::Symbol=:auto`: solver to use for the eigenvalues, one of `:eig`(default), 
+    `:eigs`
+- `inverse::Bool=false`: perform calculation for inverse transform
+- `beta::Real=1.0`: strength of the ridge regression that learns the inverse transform 
+    when inverse is true
+- `tol::Real=0.0`: Convergence tolerance for eigs solver
+- `maxiter::Int=300`: maximum number of iterations for eigs solver
+"""
+@mlj_model mutable struct KernelPCA <: MMI.Unsupervised
+    maxoutdim::Int = 0::(_ ≥ 0)
+    kernel::Union{Nothing, Function} = default_kernel
+    solver::Symbol = :eig::(_ in (:eig, :eigs))
+    inverse::Bool = false
+    beta::Real = 1.0::(_ ≥ 0.0)
+    tol::Real = 1e-6::(_ ≥ 0.0)
+    maxiter::Int = 300::(_ ≥ 1)
+end
+
+function MMI.fit(model::KernelPCA, verbosity::Int, X)
+    Xarray = MMI.matrix(X)
+    mindim = minimum(size(Xarray))
+    # default max out dim if not given
+    maxoutdim = model.maxoutdim == 0 ? mindim : model.maxoutdim
+    fitresult = MS.fit(
+        MS.KernelPCA, 
+        permutedims(Xarray);
+        kernel=model.kernel,
+        maxoutdim=maxoutdim,
+        solver=model.solver,
+        inverse=model.inverse,
+        β=model.beta,tol=model.tol,
+        maxiter=model.maxiter
+    )
+    cache  = nothing
+    report = (
+        indim=MS.indim(fitresult),
+        outdim=MS.outdim(fitresult),
+        principalvars=copy(MS.principalvars(fitresult))
+    )
+    return fitresult, cache, report
+end
+
+function MMI.fitted_params(::KernelPCA, fr)
+    return (projection=copy(MS.projection(fr)),)
+end
+
+function MMI.transform(::KernelPCA, fr::KernelPCAFitResultType, X)
+    # X is n x d, need to transpose twice...
+    Xarray = MMI.matrix(X)
+    Xnew = transpose(MS.transform(fr, transpose(Xarray)))
+    return MMI.table(Xnew, prototype=X)
+end
+
+metadata_model(
+    KernelPCA,
+    input=Table(Continuous),
+    output=Table(Continuous),
+    weights=false,
+    descr=KPCA_DESCR,
+    path="$(PKG).KernelPCA"
+)
+
+
+####
+#### ICA
+####
+
+"""
+    ICA(; kwargs...)
+
+$ICA_DESCR
+
+# Keyword Parameters
+
+- `k::Int=0`: number of independent components to recover, set automatically if `0`
+- `alg::Symbol=:fastica`: algorithm to use (only `:fastica` is supported at the moment)
+- `fun::Symbol=:tanh`: approximate neg-entropy functor, via the function 
+    `MultivariateStats.icagfun`, one of `:tanh` and `:gaus`
+- `do_whiten::Bool=true`: whether to perform pre-whitening
+- `maxiter::Int=100`: maximum number of iterations
+- `tol::Real=1e-6`: convergence tolerance for change in matrix W
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: mean to use, if nothing (default) 
+    centering is computed andapplied, if zero, no centering, a vector of means can 
+    be passed
+- `winit::Union{Nothing,Matrix{<:Real}}=nothing`: initial guess for matrix `W` either 
+    an empty matrix (random initilization of `W`), a matrix of size `k × k` (if `do_whiten` 
+    is true), a matrix of size `m × k` otherwise. If unspecified i.e `nothing` an empty 
+    `Matrix{<:Real}` is used.
+"""
+@mlj_model mutable struct ICA <: MMI.Unsupervised
+    k::Int = 0::(_ ≥ 0)
+    alg::Symbol = :fastica::(_ in (:fastica,))
+    fun::Symbol = :tanh::(_ in (:tanh, :gaus))
+    do_whiten::Bool = true
+    maxiter::Int=100::(_ ≥ 1)
+    tol::Real = 1e-6::(_ ≥ 0.0)
+    winit::Union{Nothing, Matrix{<:Real}}= nothing
+    mean::Union{Nothing, Real, Vector{Float64}} = nothing::(_check_typeof_mean(_))
+end
+
+function MMI.fit(model::ICA, verbosity::Int, X)
+    Xarray = MMI.matrix(X)
+    n, p = size(Xarray)
+    m = min(n, p)
+    k = ifelse(model.k ≤ m, model.k, m)
+    fitresult = MS.fit(
+        MS.ICA, transpose(Xarray), k;
+        alg=model.alg,
+        fun=MS.icagfun(model.fun, eltype(Xarray)),
+        do_whiten=model.do_whiten,
+        maxiter=model.maxiter,
+        tol=model.tol,
+        mean=model.mean,
+        winit=model.winit === nothing ? zeros(eltype(Xarray), 0, 0) : model.winit
+    )
+    cache = nothing
+    report = (
+        indim=MS.indim(fitresult),
+        outdim=MS.outdim(fitresult),
+        mean=copy(MS.mean(fitresult))
+    )
+    return fitresult, cache, report
+end
+
+function MMI.fitted_params(::ICA, fr)
+    return (projection=copy(MS.projection(fr)),)
+end
+
+function MMI.transform(::ICA, fr::ICAFitResultType, X)
+    # X is n x d, need to transpose twice...
+    Xarray = MMI.matrix(X)
+    Xnew = transpose(MS.transform(fr, transpose(Xarray)))
+    return MMI.table(Xnew, prototype=X)
+end
+
+metadata_model(
+    ICA,
+    input=Table(Continuous),
+    output=Table(Continuous),
+    weights=false,
+    descr=ICA_DESCR,
+    path="$(PKG).ICA"
+)
+
+####
+#### PPCA
+####
+
+"""
+    PPCA(; kwargs...)
+
+$PPCA_DESCR
+
+# Keyword Parameters
+
+- `maxoutdim::Int=0`: maximum number of output dimensions, uses max(no_of_features - 1, 1) 
+    if 0 (default).
+- `method::Symbol=:ml`: method to use to solve the problem, one of `:ml`, `:em`, `:bayes`.
+- `maxiter::Int=1000`: maximum number of iterations.
+- `tol::Real=1e-6`: convergence tolerance.
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: if set to nothing(default)  
+    centering will be computed and applied, if set to `0` no 
+    centering(assumed pre-centered), if a vector is passed, the centering is done with 
+    that vector.
+"""
+@mlj_model mutable struct PPCA <: MMI.Unsupervised
+    maxoutdim::Int = 0::(_ ≥ 0)
+    method::Symbol = :ml::(_ in (:ml, :em, :bayes))
+    maxiter::Int = 1000
+    tol::Real = 1e-6::(_ ≥ 0.0)
+    mean::Union{Nothing, Real, Vector{Float64}} = nothing::(_check_typeof_mean(_))
+end
+
+function MMI.fit(model::PPCA, verbosity::Int, X)
+    Xarray = MMI.matrix(X)
+    def_dim = max(1, size(Xarray, 2) - 1)
+    maxoutdim = model.maxoutdim == 0 ? def_dim : model.maxoutdim
+    # NOTE: copy/transpose
+    fitresult = MS.fit(
+        MS.PPCA, transpose(Xarray);
+        method=model.method,
+        tol=model.tol,
+        maxiter=model.maxiter,
+        maxoutdim=maxoutdim,
+        mean=model.mean
+    )
+    cache = nothing
+    report = (
+        indim=MS.indim(fitresult),
+        outdim=MS.outdim(fitresult),
+        tvar=MS.var(fitresult),
+        mean=copy(MS.mean(fitresult)),
+        loadings=MS.loadings(fitresult)
+    )
+    return fitresult, cache, report
+end
+
+function MMI.fitted_params(::PPCA, fr)
+    return (projection=copy(MS.projection(fr)),)
+end
+
+function MMI.transform(::PPCA, fr::PPCAFitResultType, X)
+    # X is n x d, need to transpose twice...
+    Xarray = MMI.matrix(X)
+    Xnew   = transpose(MS.transform(fr, transpose(Xarray)))
+    return MMI.table(Xnew, prototype=X)
+end
+
+metadata_model(PPCA,
+    input=Table(Continuous),
+    output=Table(Continuous),
+    weights=false,
+    descr=PPCA_DESCR,
+    path="$(PKG).PPCA"
+)
+
+####
+#### FactorAnalysis
+####
+
+"""
+    FactorAnalysis(; kwargs...)
+
+$PPCA_DESCR
+
+# Keyword Parameters
+
+- `method::Symbol=:cm`: Method to use to solve the problem, one of `:ml`, `:em`, `:bayes`.
+- `maxoutdim::Int=0`: Maximum number of output dimensions, uses max(no_of_features - 1, 1) 
+    if 0 (default).
+- `maxiter::Int=1000`: Maximum number of iterations.
+- `tol::Real=1e-6`: Convergence tolerance.
+- `eta::Real=tol`: Variance lower bound
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: If set to nothing(default)  
+    centering will be computed and applied, if set to `0` no 
+    centering(assumed pre-centered), if a vector is passed, the centering is done with 
+    that vector.
+"""
+@mlj_model mutable struct FactorAnalysis <: MMI.Unsupervised
+    method::Symbol=:cm::(_ in (:em, :cm))
+    maxoutdim::Int=0::(_ ≥ 0)
+    maxiter::Int=1000::(_ ≥ 1)
+    tol::Real=1e-6::(_ ≥ 0.0)
+    eta::Real=tol::(_ ≥ 0.0)
+    mean::Union{Nothing, Real, Vector{Float64}} = nothing::(_check_typeof_mean(_))
+end
+
+function MMI.fit(model::FactorAnalysis, verbosity::Int, X)
+    Xarray = MMI.matrix(X)
+    def_dim = max(1, size(Xarray, 2) - 1)
+    maxoutdim = model.maxoutdim == 0 ? def_dim : model.maxoutdim
+    # NOTE: copy/transpose
+    fitresult = MS.fit(
+        MS.FactorAnalysis, transpose(Xarray);
+        method=model.method,
+        maxiter=model.maxiter,
+        tol=model.tol,
+        η=model.eta,
+        maxoutdim=maxoutdim,
+        mean=model.mean
+    )
+    cache = nothing
+    report = (
+        indim=MS.indim(fitresult),
+        outdim=MS.outdim(fitresult),
+        variance=MS.var(fitresult),
+        covariance_matrix=MS.cov(fitresult),
+        mean=MS.mean(fitresult),
+        loadings=MS.loadings(fitresult)
+    )
+    return fitresult, cache, report
+end
+
+function MMI.fitted_params(::FactorAnalysis, fr)
+    return (projection=MS.projection(fr),)
+end
+
+function MMI.transform(::FactorAnalysis, fr::FactorAnalysisResultType, X)
+    # X is n x d, need to transpose twice
+    Xarray = MMI.matrix(X)
+    Xnew = transpose(MS.transform(fr, transpose(Xarray)))
+    return MMI.table(Xnew, prototype=X)
+end
+
+metadata_model(FactorAnalysis,
+    input=Table(Continuous),
+    output=Table(Continuous),
+    weights=false,
+    descr=FactorAnalysis_DESCR,
+    path="$(PKG).FactorAnalysis"
+)

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -1,0 +1,522 @@
+####
+#### MulticlassLDA
+####
+"""
+    LDA(; kwargs...)
+
+$LDA_DESCR
+
+# Keyword Parameters
+
+- `method::Symbol=:gevd`:  choice of solver, one of `:gevd` or `:whiten` methods
+- `cov_w::CovarianceEstimator`=SimpleCovariance: an estimator for the within-class 
+    covariance (used in computing within-class scatter matrix, Sw), by default set
+    to the standard `MultivariateStats.SimpleCovariance()` but 
+    could be set to any robust estimator from `CovarianceEstimation.jl`.
+- `cov_b::CovarianceEstimator`=SimpleCovariance: same as `cov_w` but for the between-class 
+    covariance (used in computing between-class scatter matrix, Sb)
+- `out_dim::Int=0`: the output dimension, i.e dimension of the transformed space, 
+    automatically set if 0 is given (default).
+- `regcoef::Float64=1e-6`: regularization coefficient (default value 1e-6). A positive 
+    value `regcoef * eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added 
+    to the diagonal of Sw to improve numerical stability. This can be useful if using 
+    the standard covariance estimator.
+- `dist::SemiMetric=SqEuclidean`: the distance metric to use when performing classification
+    (to compare the distance between a new point and centroids in the transformed space), 
+    an alternative choice can be the `CosineDist`.Defaults to `SqEuclidean`
+
+See also the 
+[package documentation](https://multivariatestatsjl.readthedocs.io/en/latest/lda.html).
+For more information about the algorithm, see the paper by Li, Zhu and Ogihara, 
+[Using Discriminant Analysis for Multi-class Classification: 
+An Experimental Investigation](http://citeseerx.ist.psu.edu/viewdoc/
+download?doi=10.1.1.89.7068&rep=rep1&type=pdf).
+"""
+@mlj_model mutable struct LDA <: MMI.Probabilistic
+    method::Symbol = :gevd::(_ in (:gevd, :whiten))
+    cov_w::CovarianceEstimator = MS.SimpleCovariance()
+    cov_b::CovarianceEstimator = MS.SimpleCovariance()
+    out_dim::Int = 0::(_ ≥ 0)
+    regcoef::Float64 = 1e-6::(_ ≥ 0)
+    dist::SemiMetric = SqEuclidean()
+end
+
+function MMI.fit(model::LDA, ::Int, X, y)
+    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim = 
+        _check_lda_data(model, X, y)
+    core_res = MS.fit(
+        MS.MulticlassLDA, nc, Xm_t, Int.(yplain);
+        method=model.method,
+        outdim=out_dim,
+        regcoef=model.regcoef,
+        covestimator_within=model.cov_w,
+        covestimator_between=model.cov_b
+    )
+    cache = nothing
+    report = (
+        classes=classes_seen,
+        out_dim=MS.outdim(core_res),
+        class_means=MS.classmeans(core_res),
+        mean=MS.mean(core_res),
+        class_weights=MS.classweights(core_res),
+        Sw=MS.withclass_scatter(core_res),
+        Sb=MS.betweenclass_scatter(core_res),
+        nc=nc
+    )
+    fitresult = (core_res, classes_seen)
+    return fitresult, cache, report
+end
+
+function _check_lda_data(model, X, y)
+    class_list = MMI.classes(y[1]) # Class list containing entries in pool of y.
+    nclasses = length(class_list)
+    # Class list containing unique entries in y.
+    classes_seen = filter(in(unique(y)), class_list) 
+    nc = length(classes_seen) # Number of classes in pool of y.
+    integers_seen = MMI.int(classes_seen)
+    # NOTE: copy/transpose.
+    Xm_t = _matrix_transpose(model, X) # Now p x n matrix
+    yplain = MMI.int(y) # Vector of n ints in {1,..., nclasses}.
+    p, n = size(Xm_t)
+    # Recode yplain to be in {1,..., nc}
+    nc == nclasses || replace!(yplain, (integers_seen .=> 1:nc)...)
+    # Check to make sure we have more than one class in training sample.
+    # This is to prevent Sb from being a zero matrix.
+    if nc <= 1
+        throw(
+            ArgumentError(
+                "The number of unique classes in "*
+                "traning sample has to be greater than one"
+            )
+        )
+    end
+
+    # Check to make sure we have more samples than classes.
+    # This is to prevent Sw from being the zero matrix.
+    if n <= nc
+        throw(
+            ArgumentError(
+                "The number of training samples `n` has"*
+                " to be greater than number of unique classes `nc`"
+            )
+        )
+    end
+    # Check output dimension default is min(p, nc-1)
+    def_outdim = min(p, nc - 1)
+    # If unset (0) use the default; otherwise try to use the provided one
+    out_dim = ifelse(model.out_dim == 0, def_outdim, model.out_dim)
+    # Check if the given one is sensible
+    if out_dim > p
+        throw(
+            ArgumentError(
+                "`out_dim` must not be larger than `p`"*
+                "where `p` is the number of features in `X`"
+            )
+        )
+    end 
+    return Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim
+end
+
+function MMI.fitted_params(::LDA, (core_res, classes_seen))
+    return (
+        projected_class_means=MS.classmeans(core_res),
+        projection_matrix=MS.projection(core_res)
+    )
+end
+
+function MMI.predict(m::LDA, (core_res, classes_seen), Xnew)
+    # projection of Xnew, XWt is nt x o  where o = number of out dims
+    # nt = number ot test samples
+    XWt = MMI.matrix(Xnew) * core_res.proj
+    # centroids in the transformed space, nc x o
+    centroids = transpose(core_res.pmeans)
+
+    # compute the distances in the transformed space between pairs of rows
+    # the probability matrix Pr is `n x nc` and normalised accross rows
+    Pr = pairwise(m.dist, XWt, centroids, dims=1)
+    Pr .= Pr .* -1
+    # apply a softmax transformation
+    softmax!(Pr)
+    return MMI.UnivariateFinite(classes_seen, Pr)
+end
+
+metadata_model(LDA,
+    input=Table(Continuous),
+    target=AbstractVector{<:Finite},
+    weights=false,
+    output=Table(Continuous),
+    descr=LDA_DESCR,
+    path="$(PKG).LDA"
+)
+    
+
+####
+#### BayesianLDA
+####
+
+"""
+    BayesianLDA(; kwargs...)
+
+$BayesianLDA_DESCR
+
+# Keyword Parameters
+
+- `method::Symbol=:gevd`: choice of solver, one of `:gevd` or `:whiten` methods
+- `cov_w::CovarianceEstimator=SimpleCovariance()`: an estimator for the within-class 
+    covariance (used in computing within-class scatter matrix, Sw), by default set to the 
+    standard `MultivariateStats.CovarianceEstimator` but could be set to any robust 
+    estimator from `CovarianceEstimation.jl`.
+- `cov_b::CovarianceEstimator=SimpleCovariance()`: same as `cov_w` but for the  
+    between-class covariance(used in computing between-class scatter matrix, Sb).
+- `out_dim::Int=0`: the output dimension, i.e dimension of the transformed space, 
+    automatically set if 0 is given (default).
+- `regcoef::Float64=1e-6`: regularization coefficient (default value 1e-6). A positive 
+value `regcoef * eigmax(Sw)` where `Sw` is the within-class covariance estimator, is added 
+    to the diagonal of Sw to improve numerical stability. This can be useful if using the 
+    standard covariance estimator.
+- `priors::Union{Nothing, Vector{Float64}}=nothing`: For use in prediction with Baye's rule. If `priors = nothing` then 
+    `priors` are estimated from the class proportions in the training data. Otherwise it 
+    requires a `Vector` containing class probabilities with probabilities specified using 
+    the order given by `levels(y)` where y is the target vector.
+
+See also the [package documentation](
+https://multivariatestatsjl.readthedocs.io/en/latest/lda.html).
+For more information about the algorithm, see the paper by Li, Zhu and Ogihara, 
+[Using Discriminant Analysis for Multi-class Classification: An Experimental Investigation](
+http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.89.7068&rep=rep1&type=pdf).
+"""
+@mlj_model mutable struct BayesianLDA <: MMI.Probabilistic
+    method::Symbol = :gevd::(_ in (:gevd, :whiten))
+    cov_w::CovarianceEstimator=MS.SimpleCovariance()
+    cov_b::CovarianceEstimator=MS.SimpleCovariance()
+    out_dim::Int=0::(_ ≥ 0)
+    regcoef::Float64=1e-6::(_ ≥ 0)
+    priors::Union{Nothing, Vector{Float64}}=nothing
+end
+
+function MMI.fit(model::BayesianLDA, ::Int, X, y)
+    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim = 
+        _check_lda_data(model, X, y) 
+    ## If piors are specified check if they makes sense.
+    ## This was put here to through errors much earlier
+    if isa(model.priors, Vector)
+        priors = _check_lda_priors(model.priors, nc, nclasses, integers_seen)         
+    end
+ 
+    core_res = MS.fit(
+        MS.MulticlassLDA, nc, Xm_t, Int.(yplain);
+        method=model.method,
+        outdim=out_dim,
+        regcoef=model.regcoef,
+        covestimator_within=model.cov_w,
+        covestimator_between=model.cov_b
+    )
+
+    ## Estimates prior probabilities if specified by user.
+    ## Put it here to avoid recomputing as the fitting process does this already
+    if isa(model.priors, Nothing)
+        weights = MS.classweights(core_res)
+        total = core_res.stats.tweight
+        priors = weights ./ total
+    end
+    cache     = nothing
+    report    = (
+        classes=classes_seen,
+        out_dim=MS.outdim(core_res),
+        class_means=MS.classmeans(core_res),
+        mean=MS.mean(core_res),
+        class_weights=MS.classweights(core_res),
+        Sw=MS.withclass_scatter(core_res),
+        Sb=MS.betweenclass_scatter(core_res),
+        nc=nc
+    )
+
+    fitresult = (core_res, classes_seen, priors, n)
+    return fitresult, cache, report
+end
+
+function _matrix_transpose(model::Union{LDA, BayesianLDA}, X)
+    return MMI.matrix(X; transpose=true)
+end
+
+function _check_lda_priors(priors, nc, nclasses, integers_seen)
+    if length(priors) != nclasses
+        throw(ArgumentError("Invalid size of `priors`."))
+    end 
+    if !isapprox(sum(priors), 1)
+        throw(ArgumentError("probabilities specified in `priors` must sum to 1"))
+    end
+    if any(model.priors .< 0)
+        throw(ArgumentError("probabilities specified in `priors` must non-negative"))
+    end
+    # Select priors for unique classes in `y` (For resampling purporses).
+    priors_ = nc == nclasses ? model.priors : @view model.priors[integers_seen]
+    return priors_
+end
+
+function MMI.fitted_params(::BayesianLDA, (core_res, classes_seen, priors, n))
+   return (
+       projected_class_means=MS.classmeans(core_res),
+       projection_matrix=MS.projection(core_res),
+       priors=priors
+    )
+end
+
+function MMI.predict(m::BayesianLDA, (core_res, classes_seen, priors, n), Xnew)
+     # projection of Xnew, XWt is nt x o  where o = number of out dims
+    # nt = number ot test samples
+    XWt = MMI.matrix(Xnew) * core_res.proj
+    # centroids in the transformed space, nc x o
+    centroids = transpose(core_res.pmeans)
+  
+    # The discriminant matrix `Pr` is of dimension `nt x nc`
+    # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σw⁻¹)(xᵢ −  µₖ) + log(priorsₖ) where (Σw = Sw/n)
+    # In the transformed space this becomes
+    # Pr[i,k] = -0.5*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(PᵀΣw⁻¹P)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
+    # But PᵀSw⁻¹P = I and PᵀΣw⁻¹P = n*I due to the nature of the projection_matrix, P
+    # Giving Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
+    # with (Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) being the SquaredEquclidean distance between
+    # pairs of rows in the transformed space
+    Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
+    Pr .*= (-0.5*n)
+    Pr .+= log.(priors)'
+
+    # apply a softmax transformation to convert Pr to a probability matrix
+    softmax!(Pr)
+    return MMI.UnivariateFinite(classes_seen, Pr)
+end
+
+function MMI.transform(m::T, (core_res,), X) where T<:Union{LDA, BayesianLDA}
+    # projection of X, XWt is nt x o  where o = out dims
+    proj = core_res.projw * core_res.projLDA #proj is the projection_matrix
+    XWt = MMI.matrix(X) * proj
+    return MMI.table(XWt, prototype = X)
+end
+
+metadata_model(
+    BayesianLDA,
+    input=Table(Continuous),
+    target= AbstractVector{<:Finite},
+    weights=false,
+    output=Table(Continuous),
+    descr=BayesianLDA_DESCR,
+    path="$(PKG).BayesianLDA"
+)
+    
+####
+#### SubspaceLDA
+####
+
+"""
+    SubspaceLDA(; kwargs...)
+
+$SubspaceLDA_DESCR
+
+# Keyword Parameters
+
+- `normalize=true`: Option to normalize the between class variance for the number of 
+    observations in each class, one of `true` or `false`.
+- `out_dim`: the dimension of the transformed space to be used by `predict` and 
+    `transform` methods, automatically set if 0 is given (default).
+- `dist=SqEuclidean`: the distance metric to use when performing classification 
+    (to compare the distance between a new point and centroids in the transformed space), 
+    an alternative choice can be the `CosineDist`.
+
+See also the [package documentation](
+https://multivariatestatsjl.readthedocs.io/en/latest/lda.html).
+For more information about the algorithm, see the paper by Howland & Park (2006),
+"Generalizing discriminant analysis using the generalized singular value decomposition",
+IEEE Trans. Patt. Anal. & Mach. Int., 26: 995-1006.
+"""
+@mlj_model mutable struct SubspaceLDA <: MMI.Probabilistic
+    normalize::Bool = true
+    out_dim::Int = 0::(_ ≥ 0)
+    dist::SemiMetric = SqEuclidean()
+end
+
+function MMI.fit(model::SubspaceLDA, ::Int, X, y)
+    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim =
+        _check_lda_data(model, X, y) 
+
+    core_res = MS.fit(
+        MS.SubspaceLDA, Xm_t, Int.(yplain), nc;
+        normalize = model.normalize
+    )
+    # λ is a (nc -1) x 1 vector containing the eigen values sorted in descending order.
+    λ = core_res.λ 
+    explained_variance_ratio = λ ./ sum(λ) #proportions of variance
+
+    cache = nothing
+    report = (
+        explained_variance_ratio=explained_variance_ratio,
+        classes=classes_seen,
+        class_means=MS.classmeans(core_res),
+        mean=MS.mean(core_res),
+        class_weights=MS.classweights(core_res),
+        nc=nc
+    )
+    fitresult = (core_res, out_dim, classes_seen)
+    return fitresult, cache, report
+end
+
+function MMI.fitted_params(::SubspaceLDA, (core_res, _))
+    return (class_means=MS.classmeans(core_res), projection_matrix=MS.projection(core_res))
+end
+
+function MMI.predict(m::SubspaceLDA, (core_res, out_dim, classes_seen), Xnew)
+     # projection of Xnew, XWt is nt x o  where o = number of out dims
+    # nt = number ot test samples
+    proj = core_res.projw * view(core_res.projLDA, :, 1:out_dim) #proj is the projection_matrix
+    XWt = MMI.matrix(Xnew) * proj
+    # centroids in the transformed space, nc x o
+    centroids = transpose(core_res.cmeans) * proj
+
+    # compute the distances in the transformed space between pairs of rows
+    # the probability matrix is `nt x nc` and normalised accross rows
+    Pr = pairwise(m.dist, XWt, centroids, dims=1)
+    Pr .= Pr .* -1
+    # apply a softmax transformation
+    softmax!(Pr)
+    return MMI.UnivariateFinite(classes_seen, Pr)
+end
+
+metadata_model(
+    SubspaceLDA,
+    input=Table(Continuous),
+    target=AbstractVector{<:Finite},
+    weights=false,
+    output=Table(Continuous),
+    descr=SubspaceLDA_DESCR,
+    path="$(PKG).SubspaceLDA"
+)
+
+####
+#### BayesianSubspaceLDA
+####
+
+"""
+    BayesianSubspaceLDA(; kwargs...)
+
+$BayesianSubspaceLDA_DESCR
+
+# Keyword Parameters
+
+- `normalize::Bool=true`: Option to normalize the between class variance for the number of
+    observations in each class, one of `true` or `false`.
+- `out_dim::Int=0`: the dimension of the transformed space to be used by `predict` and 
+    `transform` methods, automatically set if 0 is given (default).
+- `priors::Union{Nothing, Vector{Float64}}=nothing`: For use in prediction with Baye's 
+    rule. If `priors = nothing` then `priors` are estimated from the class proportions 
+    in the training data. Otherwise it requires a `Vector` containing class 
+    probabilities with probabilities specified using the order given by `levels(y)` 
+    where y is the target vector.
+
+For more information about the algorithm, see the paper by Howland & Park (2006), 
+"Generalizing discriminant analysis using the generalized singular value decomposition"
+,IEEE Trans. Patt. Anal. & Mach. Int., 26: 995-1006.
+"""
+@mlj_model mutable struct BayesianSubspaceLDA <: MMI.Probabilistic
+    normalize::Bool=false
+    out_dim::Int= 0::(_ ≥ 0)
+    priors::Union{Nothing, Vector{Float64}}=nothing
+end
+
+function MMI.fit(model::BayesianSubspaceLDA, ::Int, X, y)
+    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim = 
+        _check_lda_data(model, X, y) 
+    ## If piors are specified check if they makes sense.
+    ## This was put here to through errors much earlier
+    if isa(model.priors, Vector)
+        priors = _check_lda_priors(model.priors, nc, nclasses, integers_seen)         
+    end
+    
+    core_res = MS.fit(
+        MS.SubspaceLDA, Xm_t, Int.(yplain), nc;
+        normalize = model.normalize
+    )
+    # λ is a (nc -1) x 1 vector containing the eigen values sorted in descending order.
+    λ = core_res.λ
+    explained_variance_ratio = λ ./ sum(λ) #proportions of variance
+    mult = model.normalize ? n : 1 #used in prediction
+
+    ## Estimates prior probabilities if specified by user.
+    ## Put it here to avoid recomputing as the fitting process does this already
+    if isa(model.priors, Nothing)
+        weights = MS.classweights(core_res)
+        priors = weights ./ n
+    end
+
+    cache = nothing
+    report = (
+        explained_variance_ratio=explained_variance_ratio,
+        classes=classes_seen,
+        class_means=MS.classmeans(core_res),
+        mean=MS.mean(core_res),
+        class_weights=MS.classweights(core_res),
+        nc=nc
+    )
+    fitresult = (core_res, out_dim, classes_seen, priors, n, mult)
+    return fitresult, cache, report
+end
+
+function _matrix_transpose(model::Union{SubspaceLDA, BayesianSubspaceLDA}, X)
+    return transpose(MMI.matrix(X))
+end 
+
+function MMI.fitted_params(::BayesianSubspaceLDA, (core_res, _, _, priors,_))
+    return (
+        projected_class_means=MS.classmeans(core_res),
+        projection_matrix=MS.projection(core_res),
+        priors=priors
+    )
+end
+
+function MMI.predict(
+    m::BayesianSubspaceLDA,
+    (core_res, out_dim, classes_seen, priors, n, mult),
+    Xnew
+)
+    # projection of Xnew, XWt is nt x o  where o = number of out dims
+    # nt = number ot test samples
+    #proj is the projection_matrix
+    proj = core_res.projw * view(core_res.projLDA, :, 1:out_dim)
+    XWt = MMI.matrix(Xnew) * proj
+    
+    # centroids in the transformed space, nc x o
+    centroids = transpose(core_res.cmeans) * proj
+    nc = length(classes_seen)
+
+    # compute the distances in the transformed space between pairs of rows
+    # The discriminant matrix `Pr` is of dimension `nt x nc`
+    # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σw⁻¹)(xᵢ −  µₖ) + log(priorsₖ) where Σw = Sw/(n-nc)
+    # In the transformed space this becomes
+    # Pr[i,k] = -0.5*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(PᵀΣw⁻¹P)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
+    # But PᵀSw⁻¹P = (1/mult)*I and PᵀΣw⁻¹P = (n-nc)/mult*I
+    # Giving Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
+    # (Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) is the SquaredEquclidean distance in the 
+    # transformed space  
+    Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
+    Pr .*= (-0.5 * (n-nc)/mult)
+    Pr .+= log.(priors)'
+
+    # apply a softmax transformation to convert Pr to a probability matrix
+    softmax!(Pr)
+    return MMI.UnivariateFinite(classes_seen, Pr)
+end
+
+function MMI.transform(m::T, (core_res, out_dim, _), X) where T<:Union{SubspaceLDA, BayesianSubspaceLDA}
+    # projection of X, XWt is nt x o  where o = out dims
+    proj = core_res.projw * view(core_res.projLDA, :, 1:out_dim) #proj is the projection_matrix
+    XWt = MMI.matrix(X) * proj
+    return MMI.table(XWt, prototype = X)
+end
+
+metadata_model(
+    BayesianSubspaceLDA,
+    input=Table(Continuous),
+    target=AbstractVector{<:Finite},
+    weights=false,
+    output=Table(Continuous),
+    descr=BayesianSubspaceLDA_DESCR,
+    path="$(PKG).BayesianSubspaceLDA"
+)

--- a/src/models/linear_models.jl
+++ b/src/models/linear_models.jl
@@ -1,0 +1,146 @@
+####
+#### LinearRegressor
+####
+
+"""
+    LinearRegressor(; bias::Bool=true)
+
+$LINEAR_DESCR
+
+# Keyword Parameters
+
+- `bias::Bool=true`: if true includes a bias term else fits without bias term.
+"""
+@mlj_model mutable struct LinearRegressor <: MMI.Deterministic
+    bias::Bool = true
+end
+
+struct LinearFitresult{F<:Real, M<:AbstractArray{F}} <: MMI.MLJType
+    sol_matrix::M
+    bias::Bool
+end
+
+_convert(common_type, x::AbstractVector) = convert(AbstractVector{common_type}, x)
+_convert(common_type, x::AbstractMatrix) = convert(AbstractMatrix{common_type}, MMI.matrix(x))
+matrix_(X::AbstractVector) = X
+matrix_(X) = MMI.matrix(X) 
+
+function _matrix(X, target)
+    Xmatrix_ = MMI.matrix(X)
+    Y_ = matrix_(target)
+    common_type = promote_type(eltype(Xmatrix_), eltype(Y_))
+    Xmatrix = _convert(common_type, Xmatrix_)
+    Y = _convert(common_type, Y_)
+    return Xmatrix, Y
+end
+
+function MMI.fit(model::LinearRegressor, verbosity::Int, X, y)
+    Xmatrix, y = _matrix(X, y)
+    θ = MS.llsq(Xmatrix, y; bias=model.bias)
+    fitresult = LinearFitresult(θ, model.bias)
+    report = NamedTuple()
+    cache = nothing
+    return fitresult, cache, report
+end
+
+function _regressor_fitted_params(fr::LinearFitresult{<:Real, <:AbstractVector})
+    return (
+        coefficients=fr.sol_matrix[1:end-Int(fr.bias)],
+        intercept=ifelse(fr.bias, fr.sol_matrix[end], nothing)
+    )
+end
+
+function _regressor_fitted_params(fr::LinearFitresult{<:Real, <:AbstractMatrix})
+    return (
+        coefficients=fr.sol_matrix[1:end-Int(fr.bias), :],
+        intercept=ifelse(fr.bias, fr.sol_matrix[end, :], nothing)
+    )
+end
+
+function MMI.fitted_params(::LinearRegressor, fr)
+    return _regressor_fitted_params(fr)
+end
+
+function _predict_regressor(fr::LinearFitresult{<:Real, <:AbstractVector}, Xmat_new)
+    if fr.bias
+        return @views Xmat_new * fr.sol_matrix[1:end-1] .+ transpose(fr.sol_matrix[end])
+    else
+        return @views Xmat_new * fr.sol_matrix[1:end-1]
+    end
+end
+
+function _predict_regressor(fr::LinearFitresult{<:Real, <:AbstractMatrix}, Xmat_new)
+    if fr.bias
+        return MMI.table(
+            Xmat_new * @view(fr.sol_matrix[1:end-1, :]) .+ transpose(
+                @view(fr.sol_matrix[end, :])
+            ),
+            prototype=Xmat_new
+        )
+    else
+        return MMI.table(Xmat_new * @view(fr.sol_matrix[1:end-1, :]), prototype=Xmat_new)
+    end
+end
+
+function MMI.predict(::LinearRegressor, fr, Xnew)
+    Xmatrix = MMI.matrix(Xnew)
+    return _predict_regressor(fr, Xmatrix)
+end
+
+metadata_model(
+    LinearRegressor,
+    input=Table(Continuous),
+    target=Union{Table(Continuous), AbstractVector{Continuous}},
+    weights=false,
+    descr=LINEAR_DESCR,
+    path="$(PKG).LinearRegressor"
+)
+
+####
+#### RidgeRegressor
+####
+
+_check_typeof_lambda(x)= x isa AbstractVecOrMat || (x isa Real && x ≥ 0)
+
+"""
+    RidgeRegressor(; lambda::Union{Real, AbstractVecOrMat}=1.0, bias::Bool=true)
+
+$RIDGE_DESCR
+
+# Keyword Parameters
+
+- `lambda::Union{Real, AbstractVecOrMat}=1.0`: non-negative parameter for the 
+    regularization strength.
+- `bias::Bool=true`: if true includes a bias term else fits without bias term.
+"""
+@mlj_model mutable struct RidgeRegressor <: MMI.Deterministic
+    lambda::Union{Real, AbstractVecOrMat} = 1.0::(_check_typeof_lambda(_))
+    bias::Bool = true
+end
+
+function MMI.fit(model::RidgeRegressor, verbosity::Int, X, y)
+    Xmatrix, y = _matrix(X, y)
+    θ = MS.ridge(Xmatrix, y, model.lambda; bias=model.bias)
+    fitresult = LinearFitresult(θ, model.bias)
+    report = NamedTuple()
+    cache = nothing
+    return fitresult, cache, report
+end
+
+function MMI.fitted_params(::RidgeRegressor, fr)
+    return _regressor_fitted_params(fr)
+end
+
+function MMI.predict(::RidgeRegressor, fr, Xnew)
+    Xmatrix = MMI.matrix(Xnew)
+    return _predict_regressor(fr, Xmatrix)
+end
+
+metadata_model(
+    RidgeRegressor,
+    input=Table(Continuous),
+    target=Union{Table(Continuous), AbstractVector{Continuous}},
+    weights=false,
+    descr=RIDGE_DESCR,
+    path="$(PKG).RidgeRegressor"
+)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,24 @@
+"""
+ softmax(X::AbstractMatrix{<:Real})
+Return the softmax computed in a numerically stable way:
+``σ(x) = exp.(x) ./ sum(exp.(x))``
+Implementation taken from NNlib.jl.
+"""
+function softmax(X::AbstractMatrix{<:Real})
+    S = copyto!(similar(X, eltype(X)), X)
+    return softmax!(S)
+end
+
+"""
+ softmax!(X::AbstractMatrix{<:Real})
+Return the softmax computed in a numerically stable way:
+``σ(x) = exp.(x) ./ sum(exp.(x))`` and store the result in the
+input matrix
+Implementation taken from NNlib.jl.
+"""
+function softmax!(X::AbstractMatrix{<:Real})
+    max_ = maximum(X, dims=2)
+    X .= exp.(X .- max_) 
+    X ./= sum(X, dims=2)
+    return X 
+end

--- a/test/models/decomposition_models.jl
+++ b/test/models/decomposition_models.jl
@@ -1,0 +1,80 @@
+X, y = @load_crabs
+
+@testset "PCA" begin
+    X_array = matrix(X)
+    pratio = 0.9999
+    # MultivariateStats PCA
+    pca_ms = MultivariateStats.fit(
+        MultivariateStats.PCA,
+        permutedims(X_array),
+        pratio=pratio
+    )
+    # MLJ PCA
+    pca_mlj = PCA(pratio=pratio)
+    test_composition_model(pca_ms, pca_mlj, X, X_array)
+end
+
+@testset "KernelPCA" begin
+    X_array = matrix(X)
+    # MultivariateStats KernelPCA
+    kpca_ms = MultivariateStats.fit(
+        MultivariateStats.KernelPCA, permutedims(X_array)
+    )
+    # MLJ KernelPCA
+    kpca_mlj = KernelPCA()
+    test_composition_model(kpca_ms, kpca_mlj, X, X_array)
+end
+
+@testset "ICA" begin
+    X_array = matrix(X)
+    k = 5
+    tolerance = 5.0
+    # MultivariateStats ICA
+    rng = StableRNG(1234) # winit gets randomly initialised
+    #Random.seed!(1234) # winit gets randomly initialised
+    ica_ms = MultivariateStats.fit(
+        MultivariateStats.ICA,
+        permutedims(X_array),
+        k;
+        tol=tolerance,
+        winit = randn(rng, eltype(X_array), size(X_array, 2), k)
+    )
+    # MLJ ICA
+    rng = StableRNG(1234) # winit gets randomly initialised
+    #Random.seed!(1234) # winit gets randomly initialised
+    ica_mlj = ICA(
+        k=k,
+        tol=tolerance,
+        winit=randn(rng, eltype(X_array), size(X_array, 2), k))
+    test_composition_model(ica_ms, ica_mlj, X, X_array)
+end
+
+@testset "PPCA" begin
+    X_array = matrix(X)
+    tolerance = 5.0
+    # MultivariateStats PPCA
+    ppca_ms = MultivariateStats.fit(
+        MultivariateStats.PPCA,
+        permutedims(X_array);
+        tol=tolerance
+    )
+    # MLJ PPCA
+    ppca_mlj = PPCA(;tol=tolerance)
+    test_composition_model(ppca_ms, ppca_mlj, X, X_array)
+end
+
+@testset "FactorAnalysis" begin
+    X_array = matrix(X)
+    tolerance = 5.0
+    eta = 0.01
+    # MultivariateStats FactorAnalysis
+    factoranalysis_ms = MultivariateStats.fit(
+        MultivariateStats.FactorAnalysis,
+        permutedims(X_array);
+        tol=tolerance,
+        η=eta
+    )
+    factoranalysis_mlj = FactorAnalysis(;tol=tolerance, eta=eta)
+    test_composition_model(factoranalysis_ms, factoranalysis_mlj, X, X_array)
+end
+

--- a/test/models/discriminant_analysis.jl
+++ b/test/models/discriminant_analysis.jl
@@ -1,0 +1,151 @@
+@testset "MulticlassLDA" begin
+    Xfull, y = @load_smarket
+    X = selectcols(Xfull, [:Lag1,:Lag2])
+    train = selectcols(Xfull, :Year) .< Dates.Date(2005)
+    test = .!train
+    Xtrain = selectrows(X, train)
+    ytrain = selectrows(y, train)
+    Xtest = selectrows(X, test)
+    ytest = selectrows(y, test)
+
+    LDA_model = LDA()
+    fitresult, = fit(LDA_model, 1, Xtrain, ytrain)
+    class_means, projection_matrix = fitted_params(LDA_model, fitresult)
+    preds = predict(LDA_model, fitresult, Xtest)
+    mce = cross_entropy(preds, ytest) |> mean
+    @test 0.685 ≤ mce ≤ 0.695
+    @test round.(class_means', sigdigits = 3) == [0.0428 0.0339; -0.0395 -0.0313]
+    d = info_dict(LDA)
+    @test d[:input_scitype] == Table(Continuous)
+    @test d[:target_scitype] == AbstractVector{<:Finite}
+    @test d[:name] == "LDA"
+end
+
+@testset "MLDA-2" begin
+    Random.seed!(1125)
+    X1 = -2 .+ randn(100, 2)
+    X2 = randn(100, 2)
+    X3 = 2 .+ randn(100, 2)
+    y1 = ones(100)
+    y2 = 2ones(100)
+    y3 = 3ones(100)
+    X = vcat(X1, X2, X3)
+    y = vcat(y1, y2, y3)
+    p = Random.randperm(300)
+    X = X[p, :]
+    y = y[p]
+    X = table(X)
+    y = categorical(y)
+    train, test = partition(eachindex(y), 0.7)
+    Xtrain = selectrows(X, train)
+    ytrain = selectrows(y, train)
+    Xtest = selectrows(X, test)
+    ytest = selectrows(y, test)
+    lda_model = LDA()
+    fitresult, = fit(lda_model, 1, Xtrain, ytrain)
+    preds = predict_mode(lda_model, fitresult, Xtest)
+    mcr = misclassification_rate(preds, ytest)
+    @test mcr ≤ 0.15
+end
+
+@testset "BayesianMulticlassLDA" begin
+    Xfull, y = @load_smarket
+    X = selectcols(Xfull, [:Lag1,:Lag2])
+    train = selectcols(Xfull, :Year) .< Dates.Date(2005)
+    test = .!train
+    Xtrain = selectrows(X, train)
+    ytrain = selectrows(y, train)
+    Xtest = selectrows(X, test)
+    ytest = selectrows(y, test)
+    BLDA_model = BayesianLDA()
+    fitresult, = fit(BLDA_model, 1, Xtrain, ytrain)
+    class_means, projection_matrix, priors = fitted_params(BLDA_model, fitresult)
+    preds = predict(BLDA_model, fitresult, Xtest)
+    mce = cross_entropy(preds, ytest) |> mean
+    @test 0.685 ≤ mce ≤ 0.695
+    @test round.(class_means', sigdigits = 3) == [0.0428 0.0339; -0.0395 -0.0313]
+    d = info_dict(BayesianLDA)
+    @test d[:input_scitype] == Table(Continuous)
+    @test d[:target_scitype] == AbstractVector{<:Finite}
+    @test d[:name] == "BayesianLDA"
+end
+
+@testset "BayesianSubspaceLDA" begin
+    X, y = @load_iris
+    LDA_model = BayesianSubspaceLDA()
+    fitresult, _, report = fit(LDA_model, 1, X, y)
+    class_means, projection_matrix, prior_probabilities = fitted_params(
+        LDA_model, fitresult
+    )
+    preds=predict(LDA_model, fitresult, X)
+    predicted_class = predict_mode(LDA_model, fitresult, X)
+    mcr = misclassification_rate(predicted_class, y)
+    mce = cross_entropy(preds, y) |> mean
+    @test mean(
+        abs.(
+            class_means' - [
+                5.006 3.428 1.462 0.246;
+                5.936 2.770 4.260 1.326;
+                6.588 2.974 5.552 2.026
+            ]
+        )
+    ) < 0.01
+    @test mean(
+        abs.(
+            projection_matrix ≈ [
+                0.0675721   0.00271023;
+  			    0.127666    0.177718;
+ 				-0.180211   -0.0767255;
+                -0.235382    0.231435
+            ]
+        )
+    ) < 0.05
+    @test round.(prior_probabilities, sigdigits=7) == [0.3333333, 0.3333333, 0.3333333]
+    @test round.(mcr, sigdigits=1) == 0.02
+    @test round.(report.explained_variance_ratio, digits=4) == [0.9915, 0.0085]
+    @test 0.04 ≤ mce ≤ 0.045
+    d = info_dict(BayesianSubspaceLDA)
+    @test d[:input_scitype] == Table(Continuous)
+    @test d[:target_scitype] == AbstractVector{<:Finite}
+    @test d[:name] == "BayesianSubspaceLDA"
+end
+
+@testset "SubspaceLDA" begin
+    Random.seed!(1125)
+    X1 = -2 .+ randn(100, 2)
+    X2 = randn(100, 2)
+    X3 = 2 .+ randn(100, 2)
+    y1 = ones(100)
+    y2 = 2ones(100)
+    y3 = 3ones(100)
+    X = vcat(X1, X2, X3)
+    y = vcat(y1, y2, y3)
+    p = Random.randperm(300)
+    X = X[p, :]
+    y = y[p]
+    X = table(X)
+    y = categorical(y)
+    train, test = partition(eachindex(y), 0.7)
+    Xtrain = selectrows(X, train)
+    ytrain = selectrows(y, train)
+    Xtest = selectrows(X, test)
+    ytest = selectrows(y, test)
+    lda_model = SubspaceLDA()
+    fitresult, = fit(lda_model, 1, Xtrain, ytrain)
+    preds = predict_mode(lda_model, fitresult, Xtest)
+    mcr = misclassification_rate(preds, ytest)
+    @test mcr ≤ 0.15
+    # MultivariateStats Linear Discriminant Analysis transform
+    proj = fitresult[1].projw
+    projLDA = fitresult[1].projLDA
+    proj = proj * projLDA
+    XWt = matrix(X) * proj
+    tlda_ms = table(XWt, prototype=X)
+    # MLJ Linear Discriminant Analysis transform
+    tlda_mlj = transform(lda_model, fitresult, X)
+    @test tlda_mlj == tlda_ms
+    d = info_dict(SubspaceLDA)
+    @test d[:input_scitype] == Table(Continuous)
+    @test d[:target_scitype] == AbstractVector{<:Finite}
+    @test d[:name] == "SubspaceLDA"
+end

--- a/test/models/linear_models.jl
+++ b/test/models/linear_models.jl
@@ -1,0 +1,71 @@
+@testset "Single-response Linear" begin
+    # Define some linear, noise-free, synthetic data:
+    # with intercept = 0.0
+    n = 1000
+    rng = StableRNG(1234)
+    X, y = MLJBase.make_regression(n, 3, noise=0, intercept=false, as_table=false, rng=rng)
+    # Train model with intercept on all data
+    linear = LinearRegressor()
+    yhat, fr = test_regression(linear, X, y)
+    # Training error
+    @test norm(yhat - y)/sqrt(n) < 1e-12
+    # Get the true intercept?
+    @test abs(fr.intercept) < 1e-10
+    d = info_dict(linear)
+    @test d[:input_scitype] == Table(Continuous)
+    @test d[:target_scitype] == Union{Table(Continuous), AbstractVector{Continuous}}
+    @test d[:name] == "LinearRegressor"
+end
+
+@testset "Multi-response Linear" begin
+    # Define some linear, noise-free, synthetic data:
+    # with intercept = 0.0
+    n = 1000
+    rng = StableRNG(1234)
+    X, Y = make_regression2(n, 3, noise=0, intercept=false, rng=rng)
+    # Train model on all data
+    linear = LinearRegressor()
+    Yhat_, fr = test_regression(linear, X, Y)
+    Yhat = MLJBase.matrix(Yhat_)
+    # Training error
+    @test norm(Yhat - Y)/sqrt(n) < 1e-12
+    # Get the true intercept?
+    @test norm(fr.intercept .- zeros(size(Y, 2))) < 1e-10
+end
+
+@testset "Single-response Ridge" begin
+    # Define some linear, noise-free, synthetic data:
+    # with intercept = 0.0
+    n = 1000
+    rng = StableRNG(1234)
+    X, y = MLJBase.make_regression(n, 3, noise=0, intercept=false, as_table=false, rng=rng)
+    # Train model with intercept on all data with no regularization
+    # and no standardization of target.
+    ridge = RidgeRegressor(lambda=0.0)
+    yhat, fr = test_regression(ridge, X, y)
+    # Training error
+    @test norm(yhat - y)/sqrt(n) < 1e-12
+    # Get the true intercept?
+    @test abs(fr.intercept) < 1e-10
+    d = info_dict(ridge)
+    @test d[:input_scitype] == Table(Continuous)
+    @test d[:target_scitype] == Union{Table(Continuous), AbstractVector{Continuous}}
+    @test d[:name] == "RidgeRegressor"
+end
+
+@testset "Multi-response Ridge" begin
+    # Define some linear, noise-free, synthetic data:
+    # with intercept = 0.0
+    n = 1000
+    rng = StableRNG(1234)
+    X, Y = make_regression2(n, 3, noise=0, intercept=false, rng=rng)
+    # Train model with intercept on all data with no regularization 
+    # and no standardization of target.
+    ridge = RidgeRegressor(lambda=0.0)
+    Yhat_, fr = test_regression(ridge, X, Y)
+    Yhat = MLJBase.matrix(Yhat_)
+    # Training error
+    @test norm(Yhat - Y)/sqrt(n) < 1e-12
+    # Get the true intercept?
+    @test norm(fr.intercept .- zeros(size(Y, 2))) < 1e-10
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,15 @@
+import MultivariateStats
+import Dates
+import Random
+
+using LinearAlgebra
+using MLJBase
+using MLJMultivariateStatsInterface
+using StableRNGs
+using Test
+
+include("testutils.jl")
+println("\nutils"); include("utils.jl")
+println("\ncomponent_analysis"); include("models/decomposition_models.jl")
+println("\ndiscriminant_analysis"); include("models/discriminant_analysis.jl")
+println("\nlinear_models"); include("models/linear_models.jl")

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -1,0 +1,34 @@
+function make_regression2(n=100, p=3, c=5;intercept=true, noise=0.1, rng=nothing)
+    if rng === nothing
+        rng = Random.GLOBAL_RNG
+    elseif rng isa Integer
+        rng = Random.MersenneTwister(rng)
+    end
+    
+    X = randn(rng, n, p)
+    X = MLJBase.augment_X(randn(rng, n, p), intercept)
+    A = randn(rng, p + Int(intercept), c)
+    Y = (X * A) .+ (noise .* randn(rng, n, c))
+    return X, Y
+end
+
+function test_regression(model, X, y)
+    fitresult, report, cache = fit(model, 0, X, y)
+    yhat = predict(model, fitresult, X)
+    fr = fitted_params(model, fitresult)
+    return yhat, fr
+end
+
+function test_composition_model(ms_model, mlj_model, X, X_array)
+    mlj_model_type = typeof(mlj_model)
+    Xtr_ms = permutedims(
+        MultivariateStats.transform(ms_model, permutedims(X_array))
+    )  
+    fitresult, _, _ = fit(mlj_model, 1, X)
+    Xtr_mlj = matrix(transform(mlj_model, fitresult, X))
+    @test Xtr_mlj ≈ Xtr_ms
+    d = info_dict(mlj_model_type)
+    @test d[:input_scitype] == Table(Continuous)
+    @test d[:output_scitype] == Table(Continuous)
+    @test d[:name] == string(mlj_model_type)
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,10 @@
+@testset "softmax" begin
+    X = rand(100,5)
+    max_ = maximum(X, dims=2)
+    exp_ = exp.(X .- max_)
+    @test isapprox(MLJMultivariateStatsInterface.softmax(X), exp_ ./ sum(exp_, dims=2))
+    X_ = MLJMultivariateStatsInterface.softmax!(X)
+    @test X_ === X
+    @test isapprox(X_, exp_ ./ sum(exp_, dims=2))     
+end
+


### PR DESCRIPTION
This PR adds implementation code and tests for the following models
1. LinearRegressor
2. RidgeRegressor
3. PCA
4. KernelPCA
4. ICA
5. PPCA
5. FactorAnalysis
6. LDA,
7. BayesianLDA
8. SubspaceLDA
9. BayesianSubspaceLDA
@vollmersj @ablaom 