### PR TITLE
test linear models with table input instead of matrix input

### DIFF
--- a/src/models/linear_models.jl
+++ b/src/models/linear_models.jl
@@ -15,15 +15,18 @@ $LINEAR_DESCR
     bias::Bool = true
 end
 
-struct LinearFitresult{F<:Real, M<:AbstractArray{F}} <: MMI.MLJType
+struct LinearFitresult{T, F<:Real, M<:AbstractArray{F}} <: MMI.MLJType
     sol_matrix::M
     bias::Bool
+    names::T
 end
 
 _convert(common_type, x::AbstractVector) = convert(AbstractVector{common_type}, x)
 _convert(common_type, x::AbstractMatrix) = convert(AbstractMatrix{common_type}, MMI.matrix(x))
 matrix_(X::AbstractVector) = X
 matrix_(X) = MMI.matrix(X) 
+_names(y::AbstractVector) = nothing
+_names(Y) = collect(MMI.schema(Y).names)
 
 function _matrix(X, target)
     Xmatrix_ = MMI.matrix(X)
@@ -31,29 +34,29 @@ function _matrix(X, target)
     common_type = promote_type(eltype(Xmatrix_), eltype(Y_))
     Xmatrix = _convert(common_type, Xmatrix_)
     Y = _convert(common_type, Y_)
-    return Xmatrix, Y
+    return Xmatrix, Y, _names(target)
 end
 
 function MMI.fit(model::LinearRegressor, verbosity::Int, X, y)
-    Xmatrix, y = _matrix(X, y)
-    θ = MS.llsq(Xmatrix, y; bias=model.bias)
-    fitresult = LinearFitresult(θ, model.bias)
+    Xmatrix, y_, target_header= _matrix(X, y)
+    θ = MS.llsq(Xmatrix, y_; bias=model.bias)
+    fitresult = LinearFitresult(θ, model.bias, target_header)
     report = NamedTuple()
     cache = nothing
     return fitresult, cache, report
 end
 
-function _regressor_fitted_params(fr::LinearFitresult{<:Real, <:AbstractVector})
+function _regressor_fitted_params(fr::LinearFitresult{Nothing, <:Real, <:AbstractVector})
     return (
         coefficients=fr.sol_matrix[1:end-Int(fr.bias)],
         intercept=ifelse(fr.bias, fr.sol_matrix[end], nothing)
     )
 end
 
-function _regressor_fitted_params(fr::LinearFitresult{<:Real, <:AbstractMatrix})
+function _regressor_fitted_params(fr::LinearFitresult{<:Vector, <:Real, <:AbstractMatrix})
     return (
         coefficients=fr.sol_matrix[1:end-Int(fr.bias), :],
-        intercept=ifelse(fr.bias, fr.sol_matrix[end, :], nothing)
+        intercept=fr.bias ? fr.sol_matrix[end, :] : nothing
     )
 end
 
@@ -61,7 +64,11 @@ function MMI.fitted_params(::LinearRegressor, fr)
     return _regressor_fitted_params(fr)
 end
 
-function _predict_regressor(fr::LinearFitresult{<:Real, <:AbstractVector}, Xmat_new)
+function _predict_regressor(
+    fr::LinearFitresult{Nothing, <:Real, <:AbstractVector},
+    Xmat_new::AbstractMatrix,
+    prototype
+)
     if fr.bias
         return @views Xmat_new * fr.sol_matrix[1:end-1] .+ transpose(fr.sol_matrix[end])
     else
@@ -69,22 +76,31 @@ function _predict_regressor(fr::LinearFitresult{<:Real, <:AbstractVector}, Xmat_
     end
 end
 
-function _predict_regressor(fr::LinearFitresult{<:Real, <:AbstractMatrix}, Xmat_new)
+function _predict_regressor(
+    fr::LinearFitresult{<:Vector, <:Real, <:AbstractMatrix},
+    Xmat_new::AbstractMatrix,
+    prototype
+)
     if fr.bias
         return MMI.table(
             Xmat_new * @view(fr.sol_matrix[1:end-1, :]) .+ transpose(
                 @view(fr.sol_matrix[end, :])
-            ),
-            prototype=Xmat_new
+            );
+            names=fr.names, 
+            prototype=prototype
         )
     else
-        return MMI.table(Xmat_new * @view(fr.sol_matrix[1:end-1, :]), prototype=Xmat_new)
+        return MMI.table(
+            Xmat_new * @view(fr.sol_matrix[1:end-1, :]);
+            names=fr.names,
+            prototype=prototype
+        )
     end
 end
 
 function MMI.predict(::LinearRegressor, fr, Xnew)
-    Xmatrix = MMI.matrix(Xnew)
-    return _predict_regressor(fr, Xmatrix)
+    Xmat_new = MMI.matrix(Xnew)
+    return _predict_regressor(fr, Xmat_new, Xnew)
 end
 
 metadata_model(
@@ -119,9 +135,9 @@ $RIDGE_DESCR
 end
 
 function MMI.fit(model::RidgeRegressor, verbosity::Int, X, y)
-    Xmatrix, y = _matrix(X, y)
-    θ = MS.ridge(Xmatrix, y, model.lambda; bias=model.bias)
-    fitresult = LinearFitresult(θ, model.bias)
+    Xmatrix, y_, target_header = _matrix(X, y)
+    θ = MS.ridge(Xmatrix, y_, model.lambda; bias=model.bias)
+    fitresult = LinearFitresult(θ, model.bias, target_header)
     report = NamedTuple()
     cache = nothing
     return fitresult, cache, report
@@ -132,8 +148,8 @@ function MMI.fitted_params(::RidgeRegressor, fr)
 end
 
 function MMI.predict(::RidgeRegressor, fr, Xnew)
-    Xmatrix = MMI.matrix(Xnew)
-    return _predict_regressor(fr, Xmatrix)
+    Xmat_new = MMI.matrix(Xnew)
+    return _predict_regressor(fr, Xmat_new, Xnew)
 end
 
 metadata_model(

--- a/test/models/linear_models.jl
+++ b/test/models/linear_models.jl
@@ -3,7 +3,7 @@
     # with intercept = 0.0
     n = 1000
     rng = StableRNG(1234)
-    X, y = MLJBase.make_regression(n, 3, noise=0, intercept=false, as_table=false, rng=rng)
+    X, y = MLJBase.make_regression(n, 3, noise=0, intercept=false, rng=rng)
     # Train model with intercept on all data
     linear = LinearRegressor()
     yhat, fr = test_regression(linear, X, y)
@@ -11,6 +11,7 @@
     @test norm(yhat - y)/sqrt(n) < 1e-12
     # Get the true intercept?
     @test abs(fr.intercept) < 1e-10
+    # Check metadata
     d = info_dict(linear)
     @test d[:input_scitype] == Table(Continuous)
     @test d[:target_scitype] == Union{Table(Continuous), AbstractVector{Continuous}}
@@ -23,14 +24,17 @@ end
     n = 1000
     rng = StableRNG(1234)
     X, Y = make_regression2(n, 3, noise=0, intercept=false, rng=rng)
+    Y_mat = MLJBase.matrix(Y)
     # Train model on all data
     linear = LinearRegressor()
-    Yhat_, fr = test_regression(linear, X, Y)
-    Yhat = MLJBase.matrix(Yhat_)
+    Yhat, fr = test_regression(linear, X, Y)
+    Yhat_mat = MLJBase.matrix(Yhat)
+    # Check if the column names is same after predict 
+    MLJBase.schema(Yhat).names == MLJBase.schema(Y).names
     # Training error
-    @test norm(Yhat - Y)/sqrt(n) < 1e-12
+    @test norm(Yhat_mat - Y_mat)/sqrt(n) < 1e-12
     # Get the true intercept?
-    @test norm(fr.intercept .- zeros(size(Y, 2))) < 1e-10
+    @test norm(fr.intercept .- zeros(size(Y_mat, 2))) < 1e-10
 end
 
 @testset "Single-response Ridge" begin
@@ -38,7 +42,7 @@ end
     # with intercept = 0.0
     n = 1000
     rng = StableRNG(1234)
-    X, y = MLJBase.make_regression(n, 3, noise=0, intercept=false, as_table=false, rng=rng)
+    X, y = MLJBase.make_regression(n, 3, noise=0, intercept=false, rng=rng)
     # Train model with intercept on all data with no regularization
     # and no standardization of target.
     ridge = RidgeRegressor(lambda=0.0)
@@ -47,6 +51,7 @@ end
     @test norm(yhat - y)/sqrt(n) < 1e-12
     # Get the true intercept?
     @test abs(fr.intercept) < 1e-10
+    # Check metadata
     d = info_dict(ridge)
     @test d[:input_scitype] == Table(Continuous)
     @test d[:target_scitype] == Union{Table(Continuous), AbstractVector{Continuous}}
@@ -59,13 +64,16 @@ end
     n = 1000
     rng = StableRNG(1234)
     X, Y = make_regression2(n, 3, noise=0, intercept=false, rng=rng)
+    Y_mat = MLJBase.matrix(Y)
     # Train model with intercept on all data with no regularization 
     # and no standardization of target.
     ridge = RidgeRegressor(lambda=0.0)
-    Yhat_, fr = test_regression(ridge, X, Y)
-    Yhat = MLJBase.matrix(Yhat_)
+    Yhat, fr = test_regression(ridge, X, Y)
+    Yhat_mat = MLJBase.matrix(Yhat)
+    # Check if the column names is same after predict 
+    MLJBase.schema(Yhat).names == MLJBase.schema(Y).names
     # Training error
-    @test norm(Yhat - Y)/sqrt(n) < 1e-12
+    @test norm(Yhat_mat - Y_mat)/sqrt(n) < 1e-12
     # Get the true intercept?
-    @test norm(fr.intercept .- zeros(size(Y, 2))) < 1e-10
+    @test norm(fr.intercept .- zeros(size(Y_mat, 2))) < 1e-10
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -9,7 +9,7 @@ function make_regression2(n=100, p=3, c=5;intercept=true, noise=0.1, rng=nothing
     X = MLJBase.augment_X(randn(rng, n, p), intercept)
     A = randn(rng, p + Int(intercept), c)
     Y = (X * A) .+ (noise .* randn(rng, n, c))
-    return X, Y
+    return MLJBase.table(X), MLJBase.table(Y, names=[Symbol("y$(i)") for i = 1:c])
 end
 
 function test_regression(model, X, y)
@@ -25,8 +25,11 @@ function test_composition_model(ms_model, mlj_model, X, X_array)
         MultivariateStats.transform(ms_model, permutedims(X_array))
     )  
     fitresult, _, _ = fit(mlj_model, 1, X)
-    Xtr_mlj = matrix(transform(mlj_model, fitresult, X))
+    Xtr_mlj_table = transform(mlj_model, fitresult, X)
+    Xtr_mlj = matrix(Xtr_mlj_table)
+    # Compare MLJ and MultivariateStats transformed matrices
     @test Xtr_mlj ≈ Xtr_ms
+    # test metadata
     d = info_dict(mlj_model_type)
     @test d[:input_scitype] == Table(Continuous)
     @test d[:output_scitype] == Table(Continuous)


### PR DESCRIPTION
Previously tests on linear models were carried out using matrix input these lead to a bug in the table output gotten from these models . This PR fixes this by  
1. testing linear and ridge regression with table input instead of matrix input.

2. adding tests for multi-target linear and ridge regression to ensure features of predicted target table and training target table are same
cc.@ablaom.