### PR TITLE
Implement MLJ inverse_transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 .#*
 *.bu
 .DS_Store
+.vscode
 sandbox/
 docs/build

--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -55,17 +55,6 @@ function MMI.fit(model::PCA, verbosity::Int, X)
     return fitresult, cache, report
 end
 
-function MMI.fitted_params(::PCA, fr)
-    return (projection=copy(MS.projection(fr)),)
-end
-
-function MMI.transform(::PCA, fr::PCAFitResultType, X)
-    # X is n x d, need to transpose twice...
-    Xarray = MMI.matrix(X)
-    Xnew = transpose(MS.transform(fr, transpose(Xarray)))
-    return MMI.table(Xnew, prototype=X)
-end
-
 metadata_model(PCA,
     input=Table(Continuous),
     output=Table(Continuous),
@@ -129,17 +118,6 @@ function MMI.fit(model::KernelPCA, verbosity::Int, X)
         principalvars=copy(MS.principalvars(fitresult))
     )
     return fitresult, cache, report
-end
-
-function MMI.fitted_params(::KernelPCA, fr)
-    return (projection=copy(MS.projection(fr)),)
-end
-
-function MMI.transform(::KernelPCA, fr::KernelPCAFitResultType, X)
-    # X is n x d, need to transpose twice...
-    Xarray = MMI.matrix(X)
-    Xnew = transpose(MS.transform(fr, transpose(Xarray)))
-    return MMI.table(Xnew, prototype=X)
 end
 
 metadata_model(
@@ -213,17 +191,6 @@ function MMI.fit(model::ICA, verbosity::Int, X)
     return fitresult, cache, report
 end
 
-function MMI.fitted_params(::ICA, fr)
-    return (projection=copy(MS.projection(fr)),)
-end
-
-function MMI.transform(::ICA, fr::ICAFitResultType, X)
-    # X is n x d, need to transpose twice...
-    Xarray = MMI.matrix(X)
-    Xnew = transpose(MS.transform(fr, transpose(Xarray)))
-    return MMI.table(Xnew, prototype=X)
-end
-
 metadata_model(
     ICA,
     input=Table(Continuous),
@@ -284,17 +251,6 @@ function MMI.fit(model::PPCA, verbosity::Int, X)
         loadings=MS.loadings(fitresult)
     )
     return fitresult, cache, report
-end
-
-function MMI.fitted_params(::PPCA, fr)
-    return (projection=copy(MS.projection(fr)),)
-end
-
-function MMI.transform(::PPCA, fr::PPCAFitResultType, X)
-    # X is n x d, need to transpose twice...
-    Xarray = MMI.matrix(X)
-    Xnew   = transpose(MS.transform(fr, transpose(Xarray)))
-    return MMI.table(Xnew, prototype=X)
 end
 
 metadata_model(PPCA,
@@ -362,17 +318,6 @@ function MMI.fit(model::FactorAnalysis, verbosity::Int, X)
     return fitresult, cache, report
 end
 
-function MMI.fitted_params(::FactorAnalysis, fr)
-    return (projection=MS.projection(fr),)
-end
-
-function MMI.transform(::FactorAnalysis, fr::FactorAnalysisResultType, X)
-    # X is n x d, need to transpose twice
-    Xarray = MMI.matrix(X)
-    Xnew = transpose(MS.transform(fr, transpose(Xarray)))
-    return MMI.table(Xnew, prototype=X)
-end
-
 metadata_model(FactorAnalysis,
     input=Table(Continuous),
     output=Table(Continuous),
@@ -380,3 +325,40 @@ metadata_model(FactorAnalysis,
     descr=FactorAnalysis_DESCR,
     path="$(PKG).FactorAnalysis"
 )
+
+####
+#### Common interface
+####
+
+model_types = [
+    (PCA, PCAFitResultType),
+    (KernelPCA, KernelPCAFitResultType),
+    (ICA, ICAFitResultType),
+    (PPCA, PPCAFitResultType),
+    (FactorAnalysis, FactorAnalysisResultType)
+]
+
+for (M, MFitResultType) in model_types
+    println("Defining methods for $M")
+
+    @eval function MMI.fitted_params(::$M, fr)
+        return (projection=copy(MS.projection(fr)),)
+    end
+
+    @eval function MMI.transform(::$M, fr::$MFitResultType, X)
+        # X is n x d, need to transpose twice
+        Xarray = MMI.matrix(X)
+        Xnew = transpose(MS.transform(fr, transpose(Xarray)))
+        return MMI.table(Xnew, prototype=X)
+    end
+
+    if hasmethod(MS.reconstruct, Tuple{MFitResultType{Float64}, Matrix{Float64}})
+        println("$M has inverse !")
+        @eval function MMI.inverse_transform(::$M, fr::$MFitResultType, Y)
+            # X is n x p, need to transpose twice
+            Yarray = MMI.matrix(Y)
+            Ynew = transpose(MS.reconstruct(fr, transpose(Yarray)))
+            return MMI.table(Ynew, prototype=Y)
+        end
+    end
+end

--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -350,7 +350,7 @@ for (M, MFitResultType) in model_types
         return MMI.table(Xnew, prototype=X)
     end
 
-    if hasmethod(MS.reconstruct, Tuple{MFitResultType{T}, Matrix{T}} where {T<:Real})
+    if hasmethod(MS.reconstruct, Tuple{MFitResultType{Float64}, Matrix{Float64}})
         @eval function MMI.inverse_transform(::$M, fr::$MFitResultType, Y)
             # X is n x p, need to transpose twice
             Yarray = MMI.matrix(Y)

--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -339,8 +339,6 @@ model_types = [
 ]
 
 for (M, MFitResultType) in model_types
-    println("Defining methods for $M")
-
     @eval function MMI.fitted_params(::$M, fr)
         return (projection=copy(MS.projection(fr)),)
     end
@@ -352,8 +350,7 @@ for (M, MFitResultType) in model_types
         return MMI.table(Xnew, prototype=X)
     end
 
-    if hasmethod(MS.reconstruct, Tuple{MFitResultType{Float64}, Matrix{Float64}})
-        println("$M has inverse !")
+    if hasmethod(MS.reconstruct, Tuple{MFitResultType{T}, Matrix{T}} where {T<:Real})
         @eval function MMI.inverse_transform(::$M, fr::$MFitResultType, Y)
             # X is n x p, need to transpose twice
             Yarray = MMI.matrix(Y)

--- a/test/models/decomposition_models.jl
+++ b/test/models/decomposition_models.jl
@@ -18,10 +18,11 @@ end
     X_array = matrix(X)
     # MultivariateStats KernelPCA
     kpca_ms = MultivariateStats.fit(
-        MultivariateStats.KernelPCA, permutedims(X_array)
+        MultivariateStats.KernelPCA, permutedims(X_array),
+        inverse=true
     )
     # MLJ KernelPCA
-    kpca_mlj = KernelPCA()
+    kpca_mlj = KernelPCA(inverse=true)
     test_composition_model(kpca_ms, kpca_mlj, X, X_array)
 end
 
@@ -46,7 +47,7 @@ end
         k=k,
         tol=tolerance,
         winit=randn(rng, eltype(X_array), size(X_array, 2), k))
-    test_composition_model(ica_ms, ica_mlj, X, X_array)
+    test_composition_model(ica_ms, ica_mlj, X, X_array, test_inverse=false)
 end
 
 @testset "PPCA" begin

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -19,7 +19,7 @@ function test_regression(model, X, y)
     return yhat, fr
 end
 
-function test_composition_model(ms_model, mlj_model, X, X_array)
+function test_composition_model(ms_model, mlj_model, X, X_array ; test_inverse=true)
     mlj_model_type = typeof(mlj_model)
     Xtr_ms = permutedims(
         MultivariateStats.transform(ms_model, permutedims(X_array))
@@ -34,4 +34,13 @@ function test_composition_model(ms_model, mlj_model, X, X_array)
     @test d[:input_scitype] == Table(Continuous)
     @test d[:output_scitype] == Table(Continuous)
     @test d[:name] == string(mlj_model_type)
+
+    if test_inverse
+        Xinv_ms = permutedims(
+            MultivariateStats.reconstruct(ms_model, permutedims(Xtr_ms))
+        )
+        Xinv_mlj_table = inverse_transform(mlj_model, fitresult, Xtr_mlj)
+        Xinv_mlj = matrix(Xinv_mlj_table)
+        @test Xinv_ms ≈ Xinv_mlj
+    end
 end


### PR DESCRIPTION
This implement the `inverse_transform` interface for the decomposition method which have a `reconstruct` method.

In addition I used a bit of metaprograming to remove a bit of duplicated code in the interfaces.