### PR TITLE
Split `LinearRegresor` and `RidgeRegressor` models

### DIFF
--- a/src/MLJMultivariateStatsInterface.jl
+++ b/src/MLJMultivariateStatsInterface.jl
@@ -14,8 +14,7 @@ using LinearAlgebra
 
 # ===================================================================
 ## EXPORTS
-export LinearRegressor, RidgeRegressor, PCA, KernelPCA, ICA, PPCA, FactorAnalysis, LDA,
-    BayesianLDA, SubspaceLDA, BayesianSubspaceLDA
+# Models are exported automatically by `@mlj_model` macro
 
 # ===================================================================
 ## Re-EXPORTS

--- a/src/MLJMultivariateStatsInterface.jl
+++ b/src/MLJMultivariateStatsInterface.jl
@@ -34,70 +34,84 @@ const FactorAnalysisResultType = MS.FactorAnalysis
 const default_kernel = (x, y) -> x'y #default kernel used in KernelPCA
 
 # Definitions of model descriptions for use in model doc-strings.
-const PCA_DESCR = """Principal component analysis. Learns a linear transformation to
-project the data  on a lower dimensional space while preserving most of the initial
-variance.
-"""
+const PCA_DESCR = """
+      Principal component analysis. Learns a linear transformation to
+    project the data  on a lower dimensional space while preserving most of the initial
+    variance.
+    """
 const KPCA_DESCR = "Kernel principal component analysis."
 const ICA_DESCR = "Independent component analysis."
 const PPCA_DESCR = "Probabilistic principal component analysis"
 const FactorAnalysis_DESCR = "Factor Analysis"
-const LDA_DESCR = """Multiclass linear discriminant analysis. The algorithm learns a
-projection matrix `P` that projects a feature matrix `Xtrain` onto a lower dimensional
-space of dimension `out_dim` such that the trace of the transformed between-class scatter
-matrix(`Pᵀ*Sb*P`) is maximized relative to the trace of the transformed within-class
-scatter matrix (`Pᵀ*Sw*P`).The projection matrix is scaled such that `Pᵀ*Sw*P=I` or
-`Pᵀ*Σw*P=I`(where `Σw` is the within-class covariance matrix) .
-Predicted class posterior probability for feature matrix `Xtest` are derived by applying
-a softmax transformationto a matrix `Pr`, such that  rowᵢ of `Pr` contains computed
-distances(based on a distance metric) in the transformed space of rowᵢ in `Xtest` to the
-centroid of each class.
-"""
-const BayesianLDA_DESCR = """Bayesian Multiclass linear discriminant analysis. The algorithm
-learns a projection matrix `P` that projects a feature matrix `Xtrain` onto a lower
-dimensional space of dimension `out_dim` such that the trace of the transformed
-between-class scatter matrix(`Pᵀ*Sb*P`) is maximized relative to the trace of the
-transformed within-class scatter matrix (`Pᵀ*Sw*P`). The projection matrix is scaled such
-that `Pᵀ*Sw*P = n` or `Pᵀ*Σw*P=I` (Where `n` is the number of training samples and `Σw`
-is the within-class covariance matrix).
-Predicted class posterior probability distibution are derived by applying Bayes rule with
-a multivariate Gaussian class-conditional distribution.
-"""
-const SubspaceLDA_DESCR = """Multiclass linear discriminant analysis. Suitable for high
-dimensional data (Avoids computing scatter matrices `Sw` ,`Sb`). The algorithm learns a
-projection matrix `P = W*L` that projects a feature matrix `Xtrain` onto a lower
-dimensional space of dimension `nc - 1` such that the trace of the transformed
-between-class scatter matrix(`Pᵀ*Sb*P`) is maximized relative to the trace of the
-transformed within-class scatter matrix (`Pᵀ*Sw*P`). The projection matrix is scaled such
-that `Pᵀ*Sw*P = mult*I` or `Pᵀ*Σw*P=mult/(n-nc)*I` (where `n` is the number of training
-samples, mult` is  one of `n` or `1` depending on whether `Sb` is normalized, `Σw` is the
-within-class covariance matrix, and `nc` is the number of unique classes in `y`) and also
-obeys `Wᵀ*Sb*p = λ*Wᵀ*Sw*p`, for every column `p` in `P`.
-Predicted class posterior probability for feature matrix `Xtest` are derived by applying a
-softmax transformation to a matrix `Pr`, such that  rowᵢ of `Pr` contains computed
-distances(based on a distance metric) in the transformed space of rowᵢ in `Xtest` to the
-centroid of each class.
-"""
-const BayesianSubspaceLDA_DESCR = """Bayesian Multiclass linear discriminant analysis.
-Suitable for high dimensional data (Avoids computing scatter matrices `Sw` ,`Sb`). The
-algorithm learns a projection matrix `P = W*L` (`Sw`), that projects a feature matrix
-`Xtrain` onto a lower dimensional space of dimension `nc-1` such that the trace of the
-transformed between-class scatter matrix(`Pᵀ*Sb*P`) is maximized relative to the trace
-of the transformed within-class scatter matrix (`Pᵀ*Sw*P`). The projection matrix is
-scaled such that `Pᵀ*Sw*P = mult*I` or `Pᵀ*Σw*P=mult/(n-nc)*I` (where `n` is the number of
-training samples, `mult` is  one of `n` or `1` depending on whether `Sb` is normalized,
-`Σw` is the within-class covariance matrix, and `nc` is the number of unique classes in
-`y`) and also obeys `Wᵀ*Sb*p = λ*Wᵀ*Sw*p`, for every column `p` in `P`.
-Posterior class probability distibution are derived by applying Bayes rule with a
-multivariate Gaussian class-conditional distribution
-"""
-const LINEAR_DESCR = """Linear regression. Learns a linear combination(s) of given
-variables to fit the responses by minimizing the squared error between.
-"""
-const RIDGE_DESCR = """Ridge regressor with regularization parameter lambda. Learns a
-linear regression with a penalty on the l2 norm of the coefficients.
-"""
-
+const LDA_DESCR = """
+      Multiclass linear discriminant analysis. The algorithm learns a
+    projection matrix `P` that projects a feature matrix `Xtrain` onto a lower dimensional
+    space of dimension `out_dim` such that the trace of the transformed between-class 
+    scatter matrix(`Pᵀ*Sb*P`) is maximized relative to the trace of the transformed 
+    within-class scatter matrix (`Pᵀ*Sw*P`).The projection matrix is scaled such that 
+    `Pᵀ*Sw*P=I` or `Pᵀ*Σw*P=I`(where `Σw` is the within-class covariance matrix) .
+    Predicted class posterior probability for feature matrix `Xtest` are derived by 
+    applying a softmax transformationto a matrix `Pr`, such that  rowᵢ of `Pr` contains 
+    computed distances(based on a distance metric) in the transformed space of rowᵢ in 
+    `Xtest` to the centroid of each class.
+    """
+const BayesianLDA_DESCR = """
+      Bayesian Multiclass linear discriminant analysis. The algorithm
+    learns a projection matrix `P` that projects a feature matrix `Xtrain` onto a lower
+    dimensional space of dimension `out_dim` such that the trace of the transformed
+    between-class scatter matrix(`Pᵀ*Sb*P`) is maximized relative to the trace of the
+    transformed within-class scatter matrix (`Pᵀ*Sw*P`). The projection matrix is scaled 
+    such that `Pᵀ*Sw*P = n` or `Pᵀ*Σw*P=I` (Where `n` is the number of training samples 
+    and `Σw` is the within-class covariance matrix).
+    Predicted class posterior probability distibution are derived by applying Bayes rule 
+    with a multivariate Gaussian class-conditional distribution.
+    """
+const SubspaceLDA_DESCR = """
+    Multiclass linear discriminant analysis. Suitable for high
+    dimensional data (Avoids computing scatter matrices `Sw` ,`Sb`). The algorithm learns a
+    projection matrix `P = W*L` that projects a feature matrix `Xtrain` onto a lower
+    dimensional space of dimension `nc - 1` such that the trace of the transformed
+    between-class scatter matrix(`Pᵀ*Sb*P`) is maximized relative to the trace of the
+    transformed within-class scatter matrix (`Pᵀ*Sw*P`). The projection matrix is scaled 
+    such that `Pᵀ*Sw*P = mult*I` or `Pᵀ*Σw*P=mult/(n-nc)*I` (where `n` is the number of 
+    training samples, mult` is  one of `n` or `1` depending on whether `Sb` is normalized, 
+    `Σw` is the within-class covariance matrix, and `nc` is the number of unique classes 
+    in `y`) and also obeys `Wᵀ*Sb*p = λ*Wᵀ*Sw*p`, for every column `p` in `P`.
+    Predicted class posterior probability for feature matrix `Xtest` are derived by 
+    applying a softmax transformation to a matrix `Pr`, such that  rowᵢ of `Pr` contains 
+    computed distances(based on a distance metric) in the transformed space of rowᵢ in 
+    `Xtest` to the centroid of each class.
+    """
+const BayesianSubspaceLDA_DESCR = """
+       Bayesian Multiclass linear discriminant analysis. Suitable for high dimensional data 
+    (Avoids computing scatter matrices `Sw` ,`Sb`). The algorithm learns a projection 
+    matrix `P = W*L` (`Sw`), that projects a feature matrix `Xtrain` onto a lower 
+    dimensional space of dimension `nc-1` such that the trace of the transformed 
+    between-class scatter matrix(`Pᵀ*Sb*P`) is maximized relative to the trace of the 
+    transformed within-class scatter matrix (`Pᵀ*Sw*P`). The projection matrix is scaled 
+    such that `Pᵀ*Sw*P = mult*I` or `Pᵀ*Σw*P=mult/(n-nc)*I` (where `n` is the number of 
+    training samples, `mult` is  one of `n` or `1` depending on whether `Sb` is normalized,
+    `Σw` is the within-class covariance matrix, and `nc` is the number of unique classes in
+    `y`) and also obeys `Wᵀ*Sb*p = λ*Wᵀ*Sw*p`, for every column `p` in `P`.
+    Posterior class probability distibution are derived by applying Bayes rule with a
+    multivariate Gaussian class-conditional distribution
+    """
+const LinearRegressor_DESCR = """
+    Linear Regression. Learns a linear combination of given
+    variables to fit the response by minimizing the squared error between.
+    """
+const MultitargetLinearRegressor_DESCR = """
+    Multitarget Linear Regression. Learns linear combinations of given
+    variables to fit the responses by minimizing the squared error between.
+    """
+const RidgeRegressor_DESCR = """
+    Ridge regressor with regularization parameter lambda. Learns a
+    linear regression with a penalty on the l2 norm of the coefficients.
+    """
+const MultitargetRidgeRegressor_DESCR = """
+    Multitarget Ridge regressor with regularization parameter lambda. Learns a
+    Multitarget linear regression with a penalty on the l2 norm of the coefficients.
+    """
 const PKG = "MLJMultivariateStatsInterface"
 
 # ===================================================================

--- a/test/models/linear_models.jl
+++ b/test/models/linear_models.jl
@@ -1,4 +1,4 @@
-@testset "Single-response Linear" begin
+@testset "LinearRegressor" begin
     # Define some linear, noise-free, synthetic data:
     # with intercept = 0.0
     n = 1000
@@ -14,7 +14,7 @@
     # Check metadata
 end
 
-@testset "Multi-response Linear" begin
+@testset "MultitargetLinearRegressor" begin
     # Define some linear, noise-free, synthetic data:
     # with intercept = 0.0
     n = 1000
@@ -22,8 +22,8 @@ end
     X, Y = make_regression2(n, 3, noise=0, intercept=false, rng=rng)
     Y_mat = MLJBase.matrix(Y)
     # Train model on all data
-    linear = LinearRegressor()
-    Yhat, fr = test_regression(linear, X, Y)
+    multi_linear = MultitargetLinearRegressor()
+    Yhat, fr = test_regression(multi_linear, X, Y)
     Yhat_mat = MLJBase.matrix(Yhat)
     # Check if the column names is same after predict
     MLJBase.schema(Yhat).names == MLJBase.schema(Y).names
@@ -33,7 +33,7 @@ end
     @test norm(fr.intercept .- zeros(size(Y_mat, 2))) < 1e-10
 end
 
-@testset "Single-response Ridge" begin
+@testset "RidgeRegressor" begin
     # Define some linear, noise-free, synthetic data:
     # with intercept = 0.0
     n = 1000
@@ -50,7 +50,7 @@ end
     # Check metadata
 end
 
-@testset "Multi-response Ridge" begin
+@testset "MultitargetRidgeRegressor" begin
     # Define some linear, noise-free, synthetic data:
     # with intercept = 0.0
     n = 1000
@@ -59,8 +59,8 @@ end
     Y_mat = MLJBase.matrix(Y)
     # Train model with intercept on all data with no regularization
     # and no standardization of target.
-    ridge = RidgeRegressor(lambda=0.0)
-    Yhat, fr = test_regression(ridge, X, Y)
+    multi_ridge = MultitargetRidgeRegressor(lambda=0.0)
+    Yhat, fr = test_regression(multi_ridge, X, Y)
     Yhat_mat = MLJBase.matrix(Yhat)
     # Check if the column names is same after predict
     MLJBase.schema(Yhat).names == MLJBase.schema(Y).names


### PR DESCRIPTION
Split `LinearRegresor` and `RidgeRegressor` into `MultitargetLinearRegressor`, `LinearRegressor`, `MultitargetRidgeRegressor`, `RidgeRegressor`. This prevents issues when creating Ensembles of these models.