### PR TITLE
Change default hyperparameter `inverse` in `KernelPCA`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,9 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Distances = "^0.9,^0.10"
 MLJModelInterface = "^0.3.5,^0.4, 1.0"
-MultivariateStats = "0.9"
+MultivariateStats = "0.9.1"
 StatsBase = "0.32, 0.33"
-julia = "1"
+julia = "1.1"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,9 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Distances = "^0.9,^0.10"
 MLJModelInterface = "^0.3.5,^0.4, 1.0"
-MultivariateStats = "0.9.1"
+MultivariateStats = "0.9"
 StatsBase = "0.32, 0.33"
-julia = "1.1"
+julia = "1.6"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJMultivariateStatsInterface"
 uuid = "1b6a4a23-ba22-4f51-9698-8599985d3728"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>", "Thibaut Lienart <thibaut.lienart@gmail.com>", "Okon Samuel <okonsamuel50@gmail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -13,7 +13,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Distances = "^0.9,^0.10"
 MLJModelInterface = "^0.3.5,^0.4, 1.0"
-MultivariateStats = "0.7, 0.8"
+MultivariateStats = "0.9"
 StatsBase = "0.32, 0.33"
 julia = "1"
 

--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -9,14 +9,14 @@ $PCA_DESCR
 
 # Keyword Parameters
 
-- `maxoutdim::Int=0`: maximum number of output dimensions, uses the smallest dimension of 
+- `maxoutdim::Int=0`: maximum number of output dimensions, uses the smallest dimension of
     training feature matrix if 0 (default).
-- `method::Symbol=:auto`: method to use to solve the problem, one of `:auto`,`:cov` 
+- `method::Symbol=:auto`: method to use to solve the problem, one of `:auto`,`:cov`
     or `:svd`
 - `pratio::Float64=0.99`: ratio of variance preserved
-- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: if set to nothing(default)  
-    centering will be computed and applied, if set to `0` no 
-    centering(assumed pre-centered), if a vector is passed, the centering is done with 
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: if set to nothing(default)
+    centering will be computed and applied, if set to `0` no
+    centering(assumed pre-centered), if a vector is passed, the centering is done with
     that vector.
 """
 @mlj_model mutable struct PCA <: MMI.Unsupervised
@@ -74,14 +74,14 @@ $KPCA_DESCR
 
 # Keyword Parameters
 
-- `maxoutdim::Int = 0`: maximum number of output dimensions, uses the smallest 
+- `maxoutdim::Int = 0`: maximum number of output dimensions, uses the smallest
     dimension of training feature matrix if 0 (default).
-- `kernel::Function=(x,y)->x'y`: kernel function of 2 vector arguments x and y, returns a 
+- `kernel::Function=(x,y)->x'y`: kernel function of 2 vector arguments x and y, returns a
     scalar value
-- `solver::Symbol=:auto`: solver to use for the eigenvalues, one of `:eig`(default), 
+- `solver::Symbol=:auto`: solver to use for the eigenvalues, one of `:eig`(default),
     `:eigs`
-- `inverse::Bool=false`: perform calculation for inverse transform
-- `beta::Real=1.0`: strength of the ridge regression that learns the inverse transform 
+- `inverse::Bool=true`: perform calculations needed for inverse transform
+- `beta::Real=1.0`: strength of the ridge regression that learns the inverse transform
     when inverse is true
 - `tol::Real=0.0`: Convergence tolerance for eigs solver
 - `maxiter::Int=300`: maximum number of iterations for eigs solver
@@ -90,7 +90,7 @@ $KPCA_DESCR
     maxoutdim::Int = 0::(_ ≥ 0)
     kernel::Union{Nothing, Function} = default_kernel
     solver::Symbol = :eig::(_ in (:eig, :eigs))
-    inverse::Bool = false
+    inverse::Bool = true
     beta::Real = 1.0::(_ ≥ 0.0)
     tol::Real = 1e-6::(_ ≥ 0.0)
     maxiter::Int = 300::(_ ≥ 1)
@@ -102,7 +102,7 @@ function MMI.fit(model::KernelPCA, verbosity::Int, X)
     # default max out dim if not given
     maxoutdim = model.maxoutdim == 0 ? mindim : model.maxoutdim
     fitresult = MS.fit(
-        MS.KernelPCA, 
+        MS.KernelPCA,
         permutedims(Xarray);
         kernel=model.kernel,
         maxoutdim=maxoutdim,
@@ -143,17 +143,17 @@ $ICA_DESCR
 
 - `k::Int=0`: number of independent components to recover, set automatically if `0`
 - `alg::Symbol=:fastica`: algorithm to use (only `:fastica` is supported at the moment)
-- `fun::Symbol=:tanh`: approximate neg-entropy functor, via the function 
+- `fun::Symbol=:tanh`: approximate neg-entropy functor, via the function
     `MultivariateStats.icagfun`, one of `:tanh` and `:gaus`
 - `do_whiten::Bool=true`: whether to perform pre-whitening
 - `maxiter::Int=100`: maximum number of iterations
 - `tol::Real=1e-6`: convergence tolerance for change in matrix W
-- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: mean to use, if nothing (default) 
-    centering is computed andapplied, if zero, no centering, a vector of means can 
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: mean to use, if nothing (default)
+    centering is computed andapplied, if zero, no centering, a vector of means can
     be passed
-- `winit::Union{Nothing,Matrix{<:Real}}=nothing`: initial guess for matrix `W` either 
-    an empty matrix (random initilization of `W`), a matrix of size `k × k` (if `do_whiten` 
-    is true), a matrix of size `m × k` otherwise. If unspecified i.e `nothing` an empty 
+- `winit::Union{Nothing,Matrix{<:Real}}=nothing`: initial guess for matrix `W` either
+    an empty matrix (random initilization of `W`), a matrix of size `k × k` (if `do_whiten`
+    is true), a matrix of size `m × k` otherwise. If unspecified i.e `nothing` an empty
     `Matrix{<:Real}` is used.
 """
 @mlj_model mutable struct ICA <: MMI.Unsupervised
@@ -216,14 +216,14 @@ $PPCA_DESCR
 
 # Keyword Parameters
 
-- `maxoutdim::Int=0`: maximum number of output dimensions, uses max(no_of_features - 1, 1) 
+- `maxoutdim::Int=0`: maximum number of output dimensions, uses max(no_of_features - 1, 1)
     if 0 (default).
 - `method::Symbol=:ml`: method to use to solve the problem, one of `:ml`, `:em`, `:bayes`.
 - `maxiter::Int=1000`: maximum number of iterations.
 - `tol::Real=1e-6`: convergence tolerance.
-- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: if set to nothing(default)  
-    centering will be computed and applied, if set to `0` no 
-    centering(assumed pre-centered), if a vector is passed, the centering is done with 
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: if set to nothing(default)
+    centering will be computed and applied, if set to `0` no
+    centering(assumed pre-centered), if a vector is passed, the centering is done with
     that vector.
 """
 @mlj_model mutable struct PPCA <: MMI.Unsupervised
@@ -278,14 +278,14 @@ $PPCA_DESCR
 # Keyword Parameters
 
 - `method::Symbol=:cm`: Method to use to solve the problem, one of `:ml`, `:em`, `:bayes`.
-- `maxoutdim::Int=0`: Maximum number of output dimensions, uses max(no_of_features - 1, 1) 
+- `maxoutdim::Int=0`: Maximum number of output dimensions, uses max(no_of_features - 1, 1)
     if 0 (default).
 - `maxiter::Int=1000`: Maximum number of iterations.
 - `tol::Real=1e-6`: Convergence tolerance.
 - `eta::Real=tol`: Variance lower bound
-- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: If set to nothing(default)  
-    centering will be computed and applied, if set to `0` no 
-    centering(assumed pre-centered), if a vector is passed, the centering is done with 
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: If set to nothing(default)
+    centering will be computed and applied, if set to `0` no
+    centering(assumed pre-centered), if a vector is passed, the centering is done with
     that vector.
 """
 @mlj_model mutable struct FactorAnalysis <: MMI.Unsupervised

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -55,7 +55,7 @@ function MMI.fit(model::LDA, ::Int, X, y)
     cache = nothing
     report = (
         classes=classes_seen,
-        out_dim=MS.outdim(core_res),
+        out_dim=MS.size(core_res)[2],
         class_means=MS.classmeans(core_res),
         mean=MS.mean(core_res),
         class_weights=MS.classweights(core_res),
@@ -221,7 +221,7 @@ function MMI.fit(model::BayesianLDA, ::Int, X, y)
     cache     = nothing
     report    = (
         classes=classes_seen,
-        out_dim=MS.outdim(core_res),
+        out_dim=MS.size(core_res)[2],
         class_means=MS.classmeans(core_res),
         mean=MS.mean(core_res),
         class_weights=MS.classweights(core_res),

--- a/test/models/decomposition_models.jl
+++ b/test/models/decomposition_models.jl
@@ -22,7 +22,7 @@ end
         inverse=true
     )
     # MLJ KernelPCA
-    kpca_mlj = KernelPCA(inverse=true)
+    kpca_mlj = KernelPCA()
     test_composition_model(kpca_ms, kpca_mlj, X, X_array)
 end
 

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -22,7 +22,7 @@ end
 function test_composition_model(ms_model, mlj_model, X, X_array ; test_inverse=true)
     mlj_model_type = typeof(mlj_model)
     Xtr_ms = permutedims(
-        MultivariateStats.transform(ms_model, permutedims(X_array))
+        MultivariateStats.predict(ms_model, permutedims(X_array))
     )  
     fitresult, _, _ = fit(mlj_model, 1, X)
     Xtr_mlj_table = transform(mlj_model, fitresult, X)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -4,7 +4,7 @@ function make_regression2(n=100, p=3, c=5;intercept=true, noise=0.1, rng=nothing
     elseif rng isa Integer
         rng = Random.MersenneTwister(rng)
     end
-    
+
     X = randn(rng, n, p)
     X = MLJBase.augment_X(randn(rng, n, p), intercept)
     A = randn(rng, p + Int(intercept), c)
@@ -23,7 +23,7 @@ function test_composition_model(ms_model, mlj_model, X, X_array ; test_inverse=t
     mlj_model_type = typeof(mlj_model)
     Xtr_ms = permutedims(
         MultivariateStats.predict(ms_model, permutedims(X_array))
-    )  
+    )
     fitresult, _, _ = fit(mlj_model, 1, X)
     Xtr_mlj_table = transform(mlj_model, fitresult, X)
     Xtr_mlj = matrix(Xtr_mlj_table)


### PR DESCRIPTION
Needs:

-  [x] merge #29 

In this PR we:

- (**mildly breaking**) Change the default value of `inverse` in `kernelPCA` to `true` (#28 )