### PR TITLE
For a 0.3 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJMultivariateStatsInterface"
 uuid = "1b6a4a23-ba22-4f51-9698-8599985d3728"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>", "Thibaut Lienart <thibaut.lienart@gmail.com>", "Okon Samuel <okonsamuel50@gmail.com>"]
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,9 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Distances = "^0.9,^0.10"
 MLJModelInterface = "^0.3.5,^0.4, 1.0"
-MultivariateStats = "0.9"
+MultivariateStats = "0.9.1"
 StatsBase = "0.32, 0.33"
-julia = "1"
+julia = "1.1"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,9 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Distances = "^0.9,^0.10"
 MLJModelInterface = "^0.3.5,^0.4, 1.0"
-MultivariateStats = "0.9.1"
+MultivariateStats = "0.9"
 StatsBase = "0.32, 0.33"
-julia = "1.1"
+julia = "1.6"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJMultivariateStatsInterface"
 uuid = "1b6a4a23-ba22-4f51-9698-8599985d3728"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>", "Thibaut Lienart <thibaut.lienart@gmail.com>", "Okon Samuel <okonsamuel50@gmail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -13,7 +13,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Distances = "^0.9,^0.10"
 MLJModelInterface = "^0.3.5,^0.4, 1.0"
-MultivariateStats = "0.7, 0.8"
+MultivariateStats = "0.9"
 StatsBase = "0.32, 0.33"
 julia = "1"
 

--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -9,14 +9,14 @@ $PCA_DESCR
 
 # Keyword Parameters
 
-- `maxoutdim::Int=0`: maximum number of output dimensions, uses the smallest dimension of 
+- `maxoutdim::Int=0`: maximum number of output dimensions, uses the smallest dimension of
     training feature matrix if 0 (default).
-- `method::Symbol=:auto`: method to use to solve the problem, one of `:auto`,`:cov` 
+- `method::Symbol=:auto`: method to use to solve the problem, one of `:auto`,`:cov`
     or `:svd`
 - `pratio::Float64=0.99`: ratio of variance preserved
-- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: if set to nothing(default)  
-    centering will be computed and applied, if set to `0` no 
-    centering(assumed pre-centered), if a vector is passed, the centering is done with 
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: if set to nothing(default)
+    centering will be computed and applied, if set to `0` no
+    centering(assumed pre-centered), if a vector is passed, the centering is done with
     that vector.
 """
 @mlj_model mutable struct PCA <: MMI.Unsupervised
@@ -74,14 +74,14 @@ $KPCA_DESCR
 
 # Keyword Parameters
 
-- `maxoutdim::Int = 0`: maximum number of output dimensions, uses the smallest 
+- `maxoutdim::Int = 0`: maximum number of output dimensions, uses the smallest
     dimension of training feature matrix if 0 (default).
-- `kernel::Function=(x,y)->x'y`: kernel function of 2 vector arguments x and y, returns a 
+- `kernel::Function=(x,y)->x'y`: kernel function of 2 vector arguments x and y, returns a
     scalar value
-- `solver::Symbol=:auto`: solver to use for the eigenvalues, one of `:eig`(default), 
+- `solver::Symbol=:auto`: solver to use for the eigenvalues, one of `:eig`(default),
     `:eigs`
-- `inverse::Bool=false`: perform calculation for inverse transform
-- `beta::Real=1.0`: strength of the ridge regression that learns the inverse transform 
+- `inverse::Bool=true`: perform calculations needed for inverse transform
+- `beta::Real=1.0`: strength of the ridge regression that learns the inverse transform
     when inverse is true
 - `tol::Real=0.0`: Convergence tolerance for eigs solver
 - `maxiter::Int=300`: maximum number of iterations for eigs solver
@@ -90,7 +90,7 @@ $KPCA_DESCR
     maxoutdim::Int = 0::(_ ≥ 0)
     kernel::Union{Nothing, Function} = default_kernel
     solver::Symbol = :eig::(_ in (:eig, :eigs))
-    inverse::Bool = false
+    inverse::Bool = true
     beta::Real = 1.0::(_ ≥ 0.0)
     tol::Real = 1e-6::(_ ≥ 0.0)
     maxiter::Int = 300::(_ ≥ 1)
@@ -102,7 +102,7 @@ function MMI.fit(model::KernelPCA, verbosity::Int, X)
     # default max out dim if not given
     maxoutdim = model.maxoutdim == 0 ? mindim : model.maxoutdim
     fitresult = MS.fit(
-        MS.KernelPCA, 
+        MS.KernelPCA,
         permutedims(Xarray);
         kernel=model.kernel,
         maxoutdim=maxoutdim,
@@ -143,17 +143,17 @@ $ICA_DESCR
 
 - `k::Int=0`: number of independent components to recover, set automatically if `0`
 - `alg::Symbol=:fastica`: algorithm to use (only `:fastica` is supported at the moment)
-- `fun::Symbol=:tanh`: approximate neg-entropy functor, via the function 
+- `fun::Symbol=:tanh`: approximate neg-entropy functor, via the function
     `MultivariateStats.icagfun`, one of `:tanh` and `:gaus`
 - `do_whiten::Bool=true`: whether to perform pre-whitening
 - `maxiter::Int=100`: maximum number of iterations
 - `tol::Real=1e-6`: convergence tolerance for change in matrix W
-- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: mean to use, if nothing (default) 
-    centering is computed andapplied, if zero, no centering, a vector of means can 
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: mean to use, if nothing (default)
+    centering is computed andapplied, if zero, no centering, a vector of means can
     be passed
-- `winit::Union{Nothing,Matrix{<:Real}}=nothing`: initial guess for matrix `W` either 
-    an empty matrix (random initilization of `W`), a matrix of size `k × k` (if `do_whiten` 
-    is true), a matrix of size `m × k` otherwise. If unspecified i.e `nothing` an empty 
+- `winit::Union{Nothing,Matrix{<:Real}}=nothing`: initial guess for matrix `W` either
+    an empty matrix (random initilization of `W`), a matrix of size `k × k` (if `do_whiten`
+    is true), a matrix of size `m × k` otherwise. If unspecified i.e `nothing` an empty
     `Matrix{<:Real}` is used.
 """
 @mlj_model mutable struct ICA <: MMI.Unsupervised
@@ -216,14 +216,14 @@ $PPCA_DESCR
 
 # Keyword Parameters
 
-- `maxoutdim::Int=0`: maximum number of output dimensions, uses max(no_of_features - 1, 1) 
+- `maxoutdim::Int=0`: maximum number of output dimensions, uses max(no_of_features - 1, 1)
     if 0 (default).
 - `method::Symbol=:ml`: method to use to solve the problem, one of `:ml`, `:em`, `:bayes`.
 - `maxiter::Int=1000`: maximum number of iterations.
 - `tol::Real=1e-6`: convergence tolerance.
-- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: if set to nothing(default)  
-    centering will be computed and applied, if set to `0` no 
-    centering(assumed pre-centered), if a vector is passed, the centering is done with 
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: if set to nothing(default)
+    centering will be computed and applied, if set to `0` no
+    centering(assumed pre-centered), if a vector is passed, the centering is done with
     that vector.
 """
 @mlj_model mutable struct PPCA <: MMI.Unsupervised
@@ -278,14 +278,14 @@ $PPCA_DESCR
 # Keyword Parameters
 
 - `method::Symbol=:cm`: Method to use to solve the problem, one of `:ml`, `:em`, `:bayes`.
-- `maxoutdim::Int=0`: Maximum number of output dimensions, uses max(no_of_features - 1, 1) 
+- `maxoutdim::Int=0`: Maximum number of output dimensions, uses max(no_of_features - 1, 1)
     if 0 (default).
 - `maxiter::Int=1000`: Maximum number of iterations.
 - `tol::Real=1e-6`: Convergence tolerance.
 - `eta::Real=tol`: Variance lower bound
-- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: If set to nothing(default)  
-    centering will be computed and applied, if set to `0` no 
-    centering(assumed pre-centered), if a vector is passed, the centering is done with 
+- `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: If set to nothing(default)
+    centering will be computed and applied, if set to `0` no
+    centering(assumed pre-centered), if a vector is passed, the centering is done with
     that vector.
 """
 @mlj_model mutable struct FactorAnalysis <: MMI.Unsupervised

--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -143,8 +143,7 @@ $ICA_DESCR
 
 - `k::Int=0`: number of independent components to recover, set automatically if `0`
 - `alg::Symbol=:fastica`: algorithm to use (only `:fastica` is supported at the moment)
-- `fun::Symbol=:tanh`: approximate neg-entropy functor, via the function 
-    `MultivariateStats.icagfun`, one of `:tanh` and `:gaus`
+- `fun::Symbol=:tanh`: approximate neg-entropy function, one of `:tanh`, `:gaus`
 - `do_whiten::Bool=true`: whether to perform pre-whitening
 - `maxiter::Int=100`: maximum number of iterations
 - `tol::Real=1e-6`: convergence tolerance for change in matrix W

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -9,26 +9,26 @@ $LDA_DESCR
 # Keyword Parameters
 
 - `method::Symbol=:gevd`:  choice of solver, one of `:gevd` or `:whiten` methods
-- `cov_w::CovarianceEstimator`=SimpleCovariance: an estimator for the within-class 
+- `cov_w::CovarianceEstimator`=SimpleCovariance: an estimator for the within-class
     covariance (used in computing within-class scatter matrix, Sw), by default set
-    to the standard `MultivariateStats.SimpleCovariance()` but 
+    to the standard `MultivariateStats.SimpleCovariance()` but
     could be set to any robust estimator from `CovarianceEstimation.jl`.
-- `cov_b::CovarianceEstimator`=SimpleCovariance: same as `cov_w` but for the between-class 
+- `cov_b::CovarianceEstimator`=SimpleCovariance: same as `cov_w` but for the between-class
     covariance (used in computing between-class scatter matrix, Sb)
-- `out_dim::Int=0`: the output dimension, i.e dimension of the transformed space, 
+- `out_dim::Int=0`: the output dimension, i.e dimension of the transformed space,
     automatically set if 0 is given (default).
-- `regcoef::Float64=1e-6`: regularization coefficient (default value 1e-6). A positive 
-    value `regcoef * eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added 
-    to the diagonal of Sw to improve numerical stability. This can be useful if using 
+- `regcoef::Float64=1e-6`: regularization coefficient (default value 1e-6). A positive
+    value `regcoef * eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added
+    to the diagonal of Sw to improve numerical stability. This can be useful if using
     the standard covariance estimator.
 - `dist::SemiMetric=SqEuclidean`: the distance metric to use when performing classification
-    (to compare the distance between a new point and centroids in the transformed space), 
+    (to compare the distance between a new point and centroids in the transformed space),
     an alternative choice can be the `CosineDist`.Defaults to `SqEuclidean`
 
-See also the 
+See also the
 [package documentation](https://multivariatestatsjl.readthedocs.io/en/latest/lda.html).
-For more information about the algorithm, see the paper by Li, Zhu and Ogihara, 
-[Using Discriminant Analysis for Multi-class Classification: 
+For more information about the algorithm, see the paper by Li, Zhu and Ogihara,
+[Using Discriminant Analysis for Multi-class Classification:
 An Experimental Investigation](http://citeseerx.ist.psu.edu/viewdoc/
 download?doi=10.1.1.89.7068&rep=rep1&type=pdf).
 """
@@ -42,7 +42,7 @@ download?doi=10.1.1.89.7068&rep=rep1&type=pdf).
 end
 
 function MMI.fit(model::LDA, ::Int, X, y)
-    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim = 
+    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim =
         _check_lda_data(model, X, y)
     core_res = MS.fit(
         MS.MulticlassLDA, nc, Xm_t, Int.(yplain);
@@ -71,15 +71,14 @@ function _check_lda_data(model, X, y)
     class_list = MMI.classes(y[1]) # Class list containing entries in pool of y.
     nclasses = length(class_list)
     # Class list containing entries in seen in y.
-    classes_seen = filter(in(y), class_list) 
+    classes_seen = filter(in(y), class_list)
     nc = length(classes_seen) # Number of classes in pool of y.
     integers_seen = MMI.int(classes_seen)
-    # NOTE: copy/transpose.
     Xm_t = _matrix_transpose(model, X) # Now p x n matrix
     yplain = MMI.int(y) # Vector of n ints in {1,..., nclasses}.
     p, n = size(Xm_t)
     # Recode yplain to be in {1,..., nc}
-    nc == nclasses || _replace!(yplain, integers_seen, 1:nc) 
+    nc == nclasses || _replace!(yplain, integers_seen, 1:nc)
     # Check to make sure we have more than one class in training sample.
     # This is to prevent Sb from being a zero matrix.
     if nc <= 1
@@ -112,7 +111,7 @@ function _check_lda_data(model, X, y)
                 "where `p` is the number of features in `X`"
             )
         )
-    end 
+    end
     return Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim
 end
 
@@ -147,7 +146,7 @@ metadata_model(LDA,
     descr=LDA_DESCR,
     path="$(PKG).LDA"
 )
-    
+
 
 ####
 #### BayesianLDA
@@ -161,26 +160,26 @@ $BayesianLDA_DESCR
 # Keyword Parameters
 
 - `method::Symbol=:gevd`: choice of solver, one of `:gevd` or `:whiten` methods
-- `cov_w::CovarianceEstimator=SimpleCovariance()`: an estimator for the within-class 
-    covariance (used in computing within-class scatter matrix, Sw), by default set to the 
-    standard `MultivariateStats.CovarianceEstimator` but could be set to any robust 
+- `cov_w::CovarianceEstimator=SimpleCovariance()`: an estimator for the within-class
+    covariance (used in computing within-class scatter matrix, Sw), by default set to the
+    standard `MultivariateStats.CovarianceEstimator` but could be set to any robust
     estimator from `CovarianceEstimation.jl`.
-- `cov_b::CovarianceEstimator=SimpleCovariance()`: same as `cov_w` but for the  
+- `cov_b::CovarianceEstimator=SimpleCovariance()`: same as `cov_w` but for the
     between-class covariance(used in computing between-class scatter matrix, Sb).
-- `out_dim::Int=0`: the output dimension, i.e dimension of the transformed space, 
+- `out_dim::Int=0`: the output dimension, i.e dimension of the transformed space,
     automatically set if 0 is given (default).
-- `regcoef::Float64=1e-6`: regularization coefficient (default value 1e-6). A positive 
-value `regcoef * eigmax(Sw)` where `Sw` is the within-class covariance estimator, is added 
-    to the diagonal of Sw to improve numerical stability. This can be useful if using the 
+- `regcoef::Float64=1e-6`: regularization coefficient (default value 1e-6). A positive
+value `regcoef * eigmax(Sw)` where `Sw` is the within-class covariance estimator, is added
+    to the diagonal of Sw to improve numerical stability. This can be useful if using the
     standard covariance estimator.
-- `priors::Union{Nothing, Vector{Float64}}=nothing`: For use in prediction with Baye's rule. If `priors = nothing` then 
-    `priors` are estimated from the class proportions in the training data. Otherwise it 
-    requires a `Vector` containing class probabilities with probabilities specified using 
+- `priors::Union{Nothing, Vector{Float64}}=nothing`: For use in prediction with Baye's rule. If `priors = nothing` then
+    `priors` are estimated from the class proportions in the training data. Otherwise it
+    requires a `Vector` containing class probabilities with probabilities specified using
     the order given by `levels(y)` where y is the target vector.
 
 See also the [package documentation](
 https://multivariatestatsjl.readthedocs.io/en/latest/lda.html).
-For more information about the algorithm, see the paper by Li, Zhu and Ogihara, 
+For more information about the algorithm, see the paper by Li, Zhu and Ogihara,
 [Using Discriminant Analysis for Multi-class Classification: An Experimental Investigation](
 http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.89.7068&rep=rep1&type=pdf).
 """
@@ -194,14 +193,14 @@ http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.89.7068&rep=rep1&type=p
 end
 
 function MMI.fit(model::BayesianLDA, ::Int, X, y)
-    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim = 
-        _check_lda_data(model, X, y) 
+    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim =
+        _check_lda_data(model, X, y)
     ## If piors are specified check if they makes sense.
     ## This was put here to through errors much earlier
     if isa(model.priors, Vector)
-        priors = _check_lda_priors(model.priors, nc, nclasses, integers_seen)         
+        priors = _check_lda_priors(model.priors, nc, nclasses, integers_seen)
     end
- 
+
     core_res = MS.fit(
         MS.MulticlassLDA, nc, Xm_t, Int.(yplain);
         method=model.method,
@@ -234,22 +233,23 @@ function MMI.fit(model::BayesianLDA, ::Int, X, y)
     return fitresult, cache, report
 end
 
-function _matrix_transpose(model::Union{LDA, BayesianLDA}, X)
-    return MMI.matrix(X; transpose=true)
+function _matrix_transpose(::Union{LDA,BayesianLDA}, X)
+    # MultivariateStats 9.0 is not supporting adjoints
+    return MMI.matrix(X, transpose=true)
 end
 
 @inline function _check_lda_priors(priors, nc, nclasses, integers_seen)
     if length(priors) != nclasses
         throw(ArgumentError("Invalid size of `priors`."))
     end
-     
+
     # `priors` is esssentially always an instance of type `Vector{Float64}`.
     # The next two conditions implicitly checks that
     # ` 0 .<= priors .<= 1` and `sum(priors) ≈ 1` are true.
     if !isapprox(sum(priors), 1)
         throw(ArgumentError("probabilities specified in `priors` must sum to 1"))
     end
-    if all(>=(0), priors) 
+    if all(>=(0), priors)
         throw(ArgumentError("probabilities specified in `priors` must non-negative"))
     end
     # Select priors for unique classes in `y` (For resampling purporses).
@@ -274,7 +274,7 @@ function MMI.predict(m::BayesianLDA, (core_res, classes_seen, priors, n), Xnew)
     XWt = MMI.matrix(Xnew) * core_res.proj
     # centroids in the transformed space, nc x o
     centroids = transpose(core_res.pmeans)
-  
+
     # The discriminant matrix `Pr` is of dimension `nt x nc`
     # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σw⁻¹)(xᵢ −  µₖ) + log(priorsₖ) where (Σw = Sw/n)
     # In the transformed space this becomes
@@ -308,7 +308,7 @@ metadata_model(
     descr=BayesianLDA_DESCR,
     path="$(PKG).BayesianLDA"
 )
-    
+
 ####
 #### SubspaceLDA
 ####
@@ -320,12 +320,12 @@ $SubspaceLDA_DESCR
 
 # Keyword Parameters
 
-- `normalize=true`: Option to normalize the between class variance for the number of 
+- `normalize=true`: Option to normalize the between class variance for the number of
     observations in each class, one of `true` or `false`.
-- `out_dim`: the dimension of the transformed space to be used by `predict` and 
+- `out_dim`: the dimension of the transformed space to be used by `predict` and
     `transform` methods, automatically set if 0 is given (default).
-- `dist=SqEuclidean`: the distance metric to use when performing classification 
-    (to compare the distance between a new point and centroids in the transformed space), 
+- `dist=SqEuclidean`: the distance metric to use when performing classification
+    (to compare the distance between a new point and centroids in the transformed space),
     an alternative choice can be the `CosineDist`.
 
 See also the [package documentation](
@@ -342,14 +342,14 @@ end
 
 function MMI.fit(model::SubspaceLDA, ::Int, X, y)
     Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim =
-        _check_lda_data(model, X, y) 
+        _check_lda_data(model, X, y)
 
     core_res = MS.fit(
         MS.SubspaceLDA, Xm_t, Int.(yplain), nc;
         normalize = model.normalize
     )
     # λ is a (nc -1) x 1 vector containing the eigen values sorted in descending order.
-    λ = core_res.λ 
+    λ = core_res.λ
     explained_variance_ratio = λ ./ sum(λ) #proportions of variance
 
     cache = nothing
@@ -409,15 +409,15 @@ $BayesianSubspaceLDA_DESCR
 
 - `normalize::Bool=true`: Option to normalize the between class variance for the number of
     observations in each class, one of `true` or `false`.
-- `out_dim::Int=0`: the dimension of the transformed space to be used by `predict` and 
+- `out_dim::Int=0`: the dimension of the transformed space to be used by `predict` and
     `transform` methods, automatically set if 0 is given (default).
-- `priors::Union{Nothing, Vector{Float64}}=nothing`: For use in prediction with Baye's 
-    rule. If `priors = nothing` then `priors` are estimated from the class proportions 
-    in the training data. Otherwise it requires a `Vector` containing class 
-    probabilities with probabilities specified using the order given by `levels(y)` 
+- `priors::Union{Nothing, Vector{Float64}}=nothing`: For use in prediction with Baye's
+    rule. If `priors = nothing` then `priors` are estimated from the class proportions
+    in the training data. Otherwise it requires a `Vector` containing class
+    probabilities with probabilities specified using the order given by `levels(y)`
     where y is the target vector.
 
-For more information about the algorithm, see the paper by Howland & Park (2006), 
+For more information about the algorithm, see the paper by Howland & Park (2006),
 "Generalizing discriminant analysis using the generalized singular value decomposition"
 ,IEEE Trans. Patt. Anal. & Mach. Int., 26: 995-1006.
 """
@@ -428,14 +428,14 @@ For more information about the algorithm, see the paper by Howland & Park (2006)
 end
 
 function MMI.fit(model::BayesianSubspaceLDA, ::Int, X, y)
-    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim = 
-        _check_lda_data(model, X, y) 
+    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, out_dim =
+        _check_lda_data(model, X, y)
     ## If piors are specified check if they makes sense.
     ## This was put here to through errors much earlier
     if isa(model.priors, Vector)
-        priors = _check_lda_priors(model.priors, nc, nclasses, integers_seen)         
+        priors = _check_lda_priors(model.priors, nc, nclasses, integers_seen)
     end
-    
+
     core_res = MS.fit(
         MS.SubspaceLDA, Xm_t, Int.(yplain), nc;
         normalize = model.normalize
@@ -466,9 +466,9 @@ function MMI.fit(model::BayesianSubspaceLDA, ::Int, X, y)
 end
 
 function _matrix_transpose(model::Union{SubspaceLDA, BayesianSubspaceLDA}, X)
-    return transpose(MMI.matrix(X))
+    return MMI.matrix(X)'
 end
- 
+
 function MMI.fitted_params(::BayesianSubspaceLDA, (core_res, _, _, priors,_))
     return (
         projected_class_means=MS.classmeans(core_res),
@@ -487,7 +487,7 @@ function MMI.predict(
     #proj is the projection_matrix
     proj = core_res.projw * view(core_res.projLDA, :, 1:out_dim)
     XWt = MMI.matrix(Xnew) * proj
-    
+
     # centroids in the transformed space, nc x o
     centroids = transpose(core_res.cmeans) * proj
     nc = length(classes_seen)
@@ -499,8 +499,8 @@ function MMI.predict(
     # Pr[i,k] = -0.5*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(PᵀΣw⁻¹P)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
     # But PᵀSw⁻¹P = (1/mult)*I and PᵀΣw⁻¹P = (n-nc)/mult*I
     # Giving Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
-    # (Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) is the SquaredEquclidean distance in the 
-    # transformed space  
+    # (Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) is the SquaredEquclidean distance in the
+    # transformed space
     Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
     Pr .*= (-(n-nc)/2mult)
     Pr .+= log.(transpose(priors))
@@ -512,7 +512,8 @@ end
 
 function MMI.transform(m::T, (core_res, out_dim, _), X) where T<:Union{SubspaceLDA, BayesianSubspaceLDA}
     # projection of X, XWt is nt x o  where o = out dims
-    proj = core_res.projw * view(core_res.projLDA, :, 1:out_dim) #proj is the projection_matrix
+    proj = core_res.projw * view(core_res.projLDA, :, 1:out_dim)
+    #proj is the projection_matrix
     XWt = MMI.matrix(X) * proj
     return MMI.table(XWt, prototype = X)
 end

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -55,7 +55,7 @@ function MMI.fit(model::LDA, ::Int, X, y)
     cache = nothing
     report = (
         classes=classes_seen,
-        out_dim=MS.outdim(core_res),
+        out_dim=MS.size(core_res)[2],
         class_means=MS.classmeans(core_res),
         mean=MS.mean(core_res),
         class_weights=MS.classweights(core_res),
@@ -221,7 +221,7 @@ function MMI.fit(model::BayesianLDA, ::Int, X, y)
     cache     = nothing
     report    = (
         classes=classes_seen,
-        out_dim=MS.outdim(core_res),
+        out_dim=MS.size(core_res)[2],
         class_means=MS.classmeans(core_res),
         mean=MS.mean(core_res),
         class_weights=MS.classweights(core_res),

--- a/test/models/decomposition_models.jl
+++ b/test/models/decomposition_models.jl
@@ -22,7 +22,7 @@ end
         inverse=true
     )
     # MLJ KernelPCA
-    kpca_mlj = KernelPCA(inverse=true)
+    kpca_mlj = KernelPCA()
     test_composition_model(kpca_ms, kpca_mlj, X, X_array)
 end
 

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -22,7 +22,7 @@ end
 function test_composition_model(ms_model, mlj_model, X, X_array ; test_inverse=true)
     mlj_model_type = typeof(mlj_model)
     Xtr_ms = permutedims(
-        MultivariateStats.transform(ms_model, permutedims(X_array))
+        MultivariateStats.predict(ms_model, permutedims(X_array))
     )  
     fitresult, _, _ = fit(mlj_model, 1, X)
     Xtr_mlj_table = transform(mlj_model, fitresult, X)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -4,7 +4,7 @@ function make_regression2(n=100, p=3, c=5;intercept=true, noise=0.1, rng=nothing
     elseif rng isa Integer
         rng = Random.MersenneTwister(rng)
     end
-    
+
     X = randn(rng, n, p)
     X = MLJBase.augment_X(randn(rng, n, p), intercept)
     A = randn(rng, p + Int(intercept), c)
@@ -23,7 +23,7 @@ function test_composition_model(ms_model, mlj_model, X, X_array ; test_inverse=t
     mlj_model_type = typeof(mlj_model)
     Xtr_ms = permutedims(
         MultivariateStats.predict(ms_model, permutedims(X_array))
-    )  
+    )
     fitresult, _, _ = fit(mlj_model, 1, X)
     Xtr_mlj_table = transform(mlj_model, fitresult, X)
     Xtr_mlj = matrix(Xtr_mlj_table)


### PR DESCRIPTION
- Bump Julia requirement to 1.6
- (**mildly breaking**) Change the default value of `inverse` in `kernelPCA` to `true` (#28)
- Internally use adjoints instead of transposes on matrixified table input, except in LDA models where `MultivariateStats.jl` lacks adjoint support (partially addresses #27)
- Add support for MultivariateStats 0.9 (#29) @testercwt 