### PR TITLE
Re-instate projection for ICA

### DIFF
--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -340,8 +340,13 @@ model_types = [
 ]
 
 for (M, MFitResultType) in model_types
-    @eval function MMI.fitted_params(::$M, fr)
-        return (projection=copy(MS.projection(fr)),)
+
+    if M !== ICA # special cased below
+        quote
+            function MMI.fitted_params(::$M, fr)
+                return (projection=copy(MS.projection(fr)),)
+            end
+        end |> eval
     end
 
     @eval function MMI.transform(::$M, fr::$MFitResultType, X)
@@ -360,3 +365,5 @@ for (M, MFitResultType) in model_types
         end
     end
 end
+
+MMI.fitted_params(::ICA, fr) = (projection=copy(fr.W), mean = copy(MS.mean(fr)))

--- a/test/models/decomposition_models.jl
+++ b/test/models/decomposition_models.jl
@@ -75,7 +75,6 @@ end
     test_composition_model(ica_ms, ica_mlj, X, X_array, test_inverse=false)
 end
 
-
 @testset "PPCA" begin
     X_array = matrix(X)
     tolerance = 5.0

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -39,4 +39,8 @@ function test_composition_model(ms_model, mlj_model, X, X_array ; test_inverse=t
         Xinv_mlj = matrix(Xinv_mlj_table)
         @test Xinv_ms ≈ Xinv_mlj
     end
+
+    # smoke test for issue #42
+    fp = MLJBase.fitted_params(mlj_model, fitresult)
+    :projection in keys(fp)
 end


### PR DESCRIPTION
Closes #42. After this PR (example as in issue):

```julia
julia> fitted_params(mach)
(projection = [0.7909023334582792 -0.32456736603197656 -0.12525744617774104; -0.9511608685088736 -0.5572780168326299 1.4522147776815675; -0.004501747870195302 -1.3248567333287313 -0.47439625543108976; 1.1679877824811369 0.8174435249324206 0.6516153532951598],
 mean = [1.3299650146336044, 1.352172428829471, 1.3768481650320188, 1.328198423321514],)
```

Note that MultivariateStats no longer appears to expose the projection (unmixing) matrix. In this PR it is extracted using non-public API, but I'm guessing this interface is reasonably stable. 

The projection matrix is of the form `m x k`  where `k` is the prescibed number of components to be separated and `m` the number input components (columns of `X`).