### PR TITLE
Fix inconsitencies in names of hyperparameters, `report` keys, and `fitted_params()` keys.  

### DIFF
--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -155,7 +155,7 @@ $ICA_DESCR
     `Matrix{<:Real}` is used.
 """
 @mlj_model mutable struct ICA <: MMI.Unsupervised
-    k::Int = 0::(_ ≥ 0)
+    outdim::Int = 0::(_ ≥ 0)
     alg::Symbol = :fastica::(_ in (:fastica,))
     fun::Symbol = :tanh::(_ in (:tanh, :gaus))
     do_whiten::Bool = true
@@ -174,7 +174,7 @@ function MMI.fit(model::ICA, verbosity::Int, X)
     Xarray = MMI.matrix(X)
     n, p = size(Xarray)
     m = min(n, p)
-    k = ifelse(model.k ≤ m, model.k, m)
+    k = ifelse(model.outdim ≤ m, model.outdim, m)
     fitresult = MS.fit(
         MS.ICA, Xarray', k;
         alg=model.alg,

--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -22,7 +22,7 @@ $PCA_DESCR
 @mlj_model mutable struct PCA <: MMI.Unsupervised
     maxoutdim::Int = 0::(_ ≥ 0)
     method::Symbol = :auto::(_ in (:auto, :cov, :svd))
-    pratio::Float64 = 0.99::(0.0 < _ ≤ 1.0)
+    variance_ratio::Float64 = 0.99::(0.0 < _ ≤ 1.0)
     mean::Union{Nothing, Real, Vector{Float64}} = nothing::(_check_typeof_mean(_))
 end
 
@@ -37,7 +37,7 @@ function MMI.fit(model::PCA, verbosity::Int, X)
     fitresult = MS.fit(
         MS.PCA, Xarray';
         method=model.method,
-        pratio=model.pratio,
+        pratio=model.variance_ratio,
         maxoutdim=maxoutdim,
         mean=model.mean
     )

--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -43,8 +43,8 @@ function MMI.fit(model::PCA, verbosity::Int, X)
     )
     cache = nothing
     report = (
-        indim=MS.size(fitresult,1),
-        outdim=MS.size(fitresult,2),
+        indim=size(fitresult)[1],
+        outdim=size(fitresult)[2],
         tprincipalvar=MS.tprincipalvar(fitresult),
         tresidualvar=MS.tresidualvar(fitresult),
         tvar=MS.var(fitresult),
@@ -112,8 +112,8 @@ function MMI.fit(model::KernelPCA, verbosity::Int, X)
     )
     cache  = nothing
     report = (
-        indim=MS.size(fitresult,1),
-        outdim=MS.size(fitresult,2),
+        indim=size(fitresult)[1],
+        outdim=size(fitresult)[2],
         principalvars=copy(MS.eigvals(fitresult))
     )
     return fitresult, cache, report
@@ -187,8 +187,8 @@ function MMI.fit(model::ICA, verbosity::Int, X)
     )
     cache = nothing
     report = (
-        indim=MS.size(fitresult,1),
-        outdim=MS.size(fitresult,2),
+        indim=size(fitresult)[1],
+        outdim=size(fitresult)[2],
         mean=copy(MS.mean(fitresult))
     )
     return fitresult, cache, report
@@ -246,8 +246,8 @@ function MMI.fit(model::PPCA, verbosity::Int, X)
     )
     cache = nothing
     report = (
-        indim=MS.size(fitresult,1),
-        outdim=MS.size(fitresult,2),
+        indim=size(fitresult)[1],
+        outdim=size(fitresult)[2],
         tvar=MS.var(fitresult),
         mean=copy(MS.mean(fitresult)),
         loadings=MS.loadings(fitresult)
@@ -309,8 +309,8 @@ function MMI.fit(model::FactorAnalysis, verbosity::Int, X)
     )
     cache = nothing
     report = (
-        indim=MS.size(fitresult,1),
-        outdim=MS.size(fitresult,2),
+        indim=size(fitresult)[1],
+        outdim=size(fitresult)[2],
         variance=MS.var(fitresult),
         covariance_matrix=MS.cov(fitresult),
         mean=MS.mean(fitresult),

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -56,7 +56,7 @@ function MMI.fit(model::LDA, ::Int, X, y)
     report = (
         classes=classes_seen,
         out_dim=MS.size(core_res)[2],
-        class_means=MS.classmeans(core_res),
+        projected_class_means=MS.classmeans(core_res),
         mean=MS.mean(core_res),
         class_weights=MS.classweights(core_res),
         Sw=MS.withclass_scatter(core_res),
@@ -221,7 +221,7 @@ function MMI.fit(model::BayesianLDA, ::Int, X, y)
     report    = (
         classes=classes_seen,
         out_dim=MS.size(core_res)[2],
-        class_means=MS.classmeans(core_res),
+        projected_class_means=MS.classmeans(core_res),
         mean=MS.mean(core_res),
         class_weights=MS.classweights(core_res),
         Sw=MS.withclass_scatter(core_res),
@@ -356,7 +356,7 @@ function MMI.fit(model::SubspaceLDA, ::Int, X, y)
     report = (
         explained_variance_ratio=explained_variance_ratio,
         classes=classes_seen,
-        class_means=MS.classmeans(core_res),
+        projected_class_means=MS.classmeans(core_res),
         mean=MS.mean(core_res),
         class_weights=MS.classweights(core_res),
         nc=nc
@@ -366,7 +366,7 @@ function MMI.fit(model::SubspaceLDA, ::Int, X, y)
 end
 
 function MMI.fitted_params(::SubspaceLDA, (core_res, _))
-    return (class_means=MS.classmeans(core_res), projection_matrix=MS.projection(core_res))
+    return (projected_class_means=MS.classmeans(core_res), projection_matrix=MS.projection(core_res))
 end
 
 function MMI.predict(m::SubspaceLDA, (core_res, out_dim, classes_seen), Xnew)
@@ -456,7 +456,7 @@ function MMI.fit(model::BayesianSubspaceLDA, ::Int, X, y)
     report = (
         explained_variance_ratio=explained_variance_ratio,
         classes=classes_seen,
-        class_means=MS.classmeans(core_res),
+        projected_class_means=MS.classmeans(core_res),
         mean=MS.mean(core_res),
         class_weights=MS.classweights(core_res),
         nc=nc

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -61,7 +61,7 @@ function MMI.fit(model::LDA, ::Int, X, y)
         class_weights=MS.classweights(core_res),
         Sw=MS.withclass_scatter(core_res),
         Sb=MS.betweenclass_scatter(core_res),
-        nc=nc
+        nclasses=nc
     )
     fitresult = (core_res, classes_seen)
     return fitresult, cache, report
@@ -226,7 +226,7 @@ function MMI.fit(model::BayesianLDA, ::Int, X, y)
         class_weights=MS.classweights(core_res),
         Sw=MS.withclass_scatter(core_res),
         Sb=MS.betweenclass_scatter(core_res),
-        nc=nc
+        nclasses=nc
     )
 
     fitresult = (core_res, classes_seen, priors, n)
@@ -359,7 +359,7 @@ function MMI.fit(model::SubspaceLDA, ::Int, X, y)
         projected_class_means=MS.classmeans(core_res),
         mean=MS.mean(core_res),
         class_weights=MS.classweights(core_res),
-        nc=nc
+        nclasses=nc,
     )
     fitresult = (core_res, outdim, classes_seen)
     return fitresult, cache, report
@@ -459,7 +459,7 @@ function MMI.fit(model::BayesianSubspaceLDA, ::Int, X, y)
         projected_class_means=MS.classmeans(core_res),
         mean=MS.mean(core_res),
         class_weights=MS.classweights(core_res),
-        nc=nc
+        nclasses=nc
     )
     fitresult = (core_res, outdim, classes_seen, priors, n, mult)
     return fitresult, cache, report

--- a/test/models/decomposition_models.jl
+++ b/test/models/decomposition_models.jl
@@ -2,15 +2,15 @@ X, y = @load_crabs
 
 @testset "PCA" begin
     X_array = matrix(X)
-    pratio = 0.9999
+    variance_ratio = 0.9999
     # MultivariateStats PCA
     pca_ms = MultivariateStats.fit(
         MultivariateStats.PCA,
         permutedims(X_array),
-        pratio=pratio
+        pratio=variance_ratio
     )
     # MLJ PCA
-    pca_mlj = PCA(pratio=pratio)
+    pca_mlj = PCA(variance_ratio=variance_ratio)
     test_composition_model(pca_ms, pca_mlj, X, X_array)
 end
 
@@ -28,7 +28,7 @@ end
 
 @testset "ICA" begin
     X_array = matrix(X)
-    k = 5
+    outdim = 5
     tolerance = 5.0
     # MultivariateStats ICA
     rng = StableRNG(1234) # winit gets randomly initialised
@@ -36,22 +36,23 @@ end
     ica_ms = MultivariateStats.fit(
         MultivariateStats.ICA,
         permutedims(X_array),
-        k;
+        outdim;
         tol=tolerance,
-        winit = randn(rng, eltype(X_array), size(X_array, 2), k)
+        winit = randn(rng, eltype(X_array), size(X_array, 2), outdim)
     )
     # MLJ ICA
     rng = StableRNG(1234) # winit gets randomly initialised
     #Random.seed!(1234) # winit gets randomly initialised
     ica_mlj = ICA(
-        k=k,
+        outdim=outdim,
         tol=tolerance,
-        winit=randn(rng, eltype(X_array), size(X_array, 2), k))
+        winit=randn(rng, eltype(X_array), size(X_array, 2), outdim))
     test_composition_model(ica_ms, ica_mlj, X, X_array, test_inverse=false)
 end
+
 @testset "ICA2" begin
     X_array = matrix(X)
-    k = 5
+    outdim = 5
     tolerance = 5.0
     # MultivariateStats ICA
     rng = StableRNG(1234) # winit gets randomly initialised
@@ -59,19 +60,19 @@ end
     ica_ms = MultivariateStats.fit(
         MultivariateStats.ICA,
         permutedims(X_array),
-        k;
+        outdim;
         tol=tolerance,
         fun=MultivariateStats.Gaus(),
-        winit = randn(rng, eltype(X_array), size(X_array, 2), k)
+        winit = randn(rng, eltype(X_array), size(X_array, 2), outdim)
     )
     # MLJ ICA
     rng = StableRNG(1234) # winit gets randomly initialised
     #Random.seed!(1234) # winit gets randomly initialised
     ica_mlj = ICA(
-        k=k,
+        outdim=outdim,
         tol=tolerance,
         fun=:gaus,
-        winit=randn(rng, eltype(X_array), size(X_array, 2), k))
+        winit=randn(rng, eltype(X_array), size(X_array, 2), outdim))
     test_composition_model(ica_ms, ica_mlj, X, X_array, test_inverse=false)
 end
 

--- a/test/models/discriminant_analysis.jl
+++ b/test/models/discriminant_analysis.jl
@@ -183,9 +183,9 @@ y1 = y[[1,1,1,1]]
 ## than unique classes during training.
 @test_throws ArgumentError fit(model, 1, X, y)
 
-## Check to make sure error is thrown if `out_dim` exceeds the number of features in
+## Check to make sure error is thrown if `outdim` exceeds the number of features in
 ## sample matrix used in training.
-model = LDA(out_dim=3)
+model = LDA(outdim=3)
 # categorical array with same pool as y but only containing "apples" & "oranges"
 y2 = y[[1,2,1,2]]
 @test_throws ArgumentError fit(model, 1, X, y2)


### PR DESCRIPTION
Closes #46. 

In this PR we:

- (**breaking**) Rename the `class_means` key in reports  to `projected_class_means`, for consistency with key name in `fitted_params(model, ...)`.  Effects `LDA` and its relatives (#46).
- (**breaking**) Rename `out_dim` in hyper-parameters and reports with `outdim` for consistency with use in other models. Effects `ICA`, and `LDA` and relatives of `LDA` (#46).
- (**breaking**) Rename the `pratio` hyperparameter in `PCA` to `variance_ratio` as more informative (#46)
- (**breaking**) Rename `nc` in reports to `nclasses` as more informative. Effects  `LDA` and its relatives (#46)
- (**breaking**) Rename hyper-parameter `k` in `ICA` to `outdim` for consistency with other models and report (#46)

To prevent merge conflicts with #39  **no changes to documentation** are made in this PR. 

cc @josephsdavid