### PR TITLE
upgrade to multivariatestats v0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>", "Thibaut Lienart <thiba
 version = "0.4.0"
 
 [deps]
+CategoricalDistributions = "af321ab8-2d2e-40a6-b165-3d674595d28e"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
@@ -11,9 +12,10 @@ MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+CategoricalDistributions = "0.1.9"
 Distances = "0.9,0.10"
 MLJModelInterface = "1.4"
-MultivariateStats = "0.9"
+MultivariateStats = "0.10"
 StatsBase = "0.32, 0.33"
 julia = "1.6"
 

--- a/src/MLJMultivariateStatsInterface.jl
+++ b/src/MLJMultivariateStatsInterface.jl
@@ -9,6 +9,7 @@ import MultivariateStats
 import MultivariateStats: SimpleCovariance
 import StatsBase: CovarianceEstimator
 
+using CategoricalDistributions
 using Distances
 using LinearAlgebra
 

--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -284,8 +284,8 @@ MMI.fitted_params(::ICA, fr) = (projection=copy(fr.W), mean = copy(MS.mean(fr)))
 
 $(MMI.doc_header(PCA))
 
-Principal component analysis learns a linear projection onto a lower dimensional space while
-preserving most of the initial variance seen in the training data.
+Principal component analysis learns a linear projection onto a lower dimensional space 
+while preserving most of the initial variance seen in the training data.
 
 # Training data
 
@@ -321,37 +321,38 @@ Train the machine using `fit!(mach, rows=...)`.
       dimension and otherwise use `:svd`
 
 - `mean=nothing`: if `nothing`, centering will be computed and applied, if set to `0` no
-  centering (data is assumed pre-centered); if a vector is passed, the centering is done
-  with that vector.
+    centering (data is assumed pre-centered); if a vector is passed, the centering is done
+    with that vector.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-  should have the same scitype as `X` above.
+    should have the same scitype as `X` above.
 
 - `inverse_transform(mach, Xsmall)`: For a dimension-reduced table `Xsmall`,
-  such as returned by `transform`, reconstruct a table, having same the number
-  of columns as the original training data `X`, that transforms to `Xsmall`.
-  Mathematically, `inverse_transform` is a right-inverse for the PCA projection
-  map, whose image is orthogonal to the kernel of that map. In particular, if
-  `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
-  only an approximation to `Xnew`.
+    such as returned by `transform`, reconstruct a table, having same the number
+    of columns as the original training data `X`, that transforms to `Xsmall`.
+    Mathematically, `inverse_transform` is a right-inverse for the PCA projection
+    map, whose image is orthogonal to the kernel of that map. In particular, if
+    `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
+    only an approximation to `Xnew`.
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
 - `projection`: Returns the projection matrix, which has size `(indim, outdim)`, where
-  `indim` and `outdim` are the number of features of the input and output respectively.
+    `indim` and `outdim` are the number of features of the input and output respectively.
 
 # Report
 
 The fields of `report(mach)` are:
 
-- `indim`: Dimension (number of columns) of the training data and new data to be transformed.
+- `indim`: Dimension (number of columns) of the training data and new data to be 
+    transformed.
 
 - `outdim = min(n, indim, maxoutdim)` is the output dimension; here `n` is the number of
-  observations.
+    observations.
 
 - `tprincipalvar`: Total variance of the principal components.
 
@@ -407,19 +408,19 @@ Train the machine using `fit!(mach, rows=...)`.
 # Hyper-parameters
 
 - `maxoutdim=0`: Controls the the dimension (number of columns) of the output,
-  `outdim`. Specifically, `outdim = min(n, indim, maxoutdim)`, where `n` is the number of
-  observations and `indim` the input dimension.
+    `outdim`. Specifically, `outdim = min(n, indim, maxoutdim)`, where `n` is the number of
+    observations and `indim` the input dimension.
 
 - `kernel::Function=(x,y)->x'y`: The kernel function, takes in 2 vector arguments
-  x and y, returns a scalar value. Defaults to the dot product of `x` and `y`.
+    x and y, returns a scalar value. Defaults to the dot product of `x` and `y`.
 
 - `solver::Symbol=:eig`: solver to use for the eigenvalues, one of `:eig`(default, uses
-  `LinearAlgebra.eigen`), `:eigs`(uses `Arpack.eigs`).
+    `LinearAlgebra.eigen`), `:eigs`(uses `Arpack.eigs`).
 
 - `inverse::Bool=true`: perform calculations needed for inverse transform
 
 - `beta::Real=1.0`: strength of the ridge regression that learns the inverse transform
-  when inverse is true.
+    when inverse is true.
 
 - `tol::Real=0.0`: Convergence tolerance for eigenvalue solver.
 
@@ -428,28 +429,29 @@ Train the machine using `fit!(mach, rows=...)`.
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-  should have the same scitype as `X` above.
+    should have the same scitype as `X` above.
 
 - `inverse_transform(mach, Xsmall)`: For a dimension-reduced table `Xsmall`, such as
-  returned by `transform`, reconstruct a table, having same the number of columns as the
-  original training data `X`, that transforms to `Xsmall`.  Mathematically,
-  `inverse_transform` is a right-inverse for the PCA projection map, whose image is
-  orthogonal to the kernel of that map. In particular, if `Xsmall = transform(mach, Xnew)`,
-  then `inverse_transform(Xsmall)` is only an approximation to `Xnew`.
+    returned by `transform`, reconstruct a table, having same the number of columns as the
+    original training data `X`, that transforms to `Xsmall`.  Mathematically,
+    `inverse_transform` is a right-inverse for the PCA projection map, whose image is
+    orthogonal to the kernel of that map. In particular, if 
+    `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is only an 
+    approximation to `Xnew`.
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
 - `projection`: Returns the projection matrix, which has size `(indim, outdim)`, where
-  `indim` and `outdim` are the number of features of the input and ouput respectively.
+    `indim` and `outdim` are the number of features of the input and ouput respectively.
 
 # Report
 
 The fields of `report(mach)` are:
 
 - `indim`: Dimension (number of columns) of the training data and new data to be
-  transformed.
+    transformed.
 
 - `outdim`: Dimension of transformed data.
 
@@ -496,15 +498,17 @@ In MLJ or MLJBase, bind an instance `model` to data with
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype
-  `Continuous`; check column scitypes with `schema(X)`.
+    `Continuous`; check column scitypes with `schema(X)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
-- `outdim::Int=0`: The number of independent components to recover, set automatically if `0`.
+- `outdim::Int=0`: The number of independent components to recover, set automatically 
+    if `0`.
 
-- `alg::Symbol=:fastica`: The algorithm to use (only `:fastica` is supported at the moment).
+- `alg::Symbol=:fastica`: The algorithm to use (only `:fastica` is supported at the 
+    moment).
 
 - `fun::Symbol=:tanh`: The approximate neg-entropy function, one of `:tanh`, `:gaus`.
 
@@ -515,18 +519,18 @@ Train the machine using `fit!(mach, rows=...)`.
 - `tol::Real=1e-6`: The convergence tolerance for change in the unmixing matrix W.
 
 - `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: mean to use, if nothing (default)
-  centering is computed and applied, if zero, no centering; otherwise a vector of means can
-  be passed.
+    centering is computed and applied, if zero, no centering; otherwise a vector of means 
+    can be passed.
 
-- `winit::Union{Nothing,Matrix{<:Real}}=nothing`: Initial guess for the unmixing matrix `W`:
-  either an empty matrix (for random initialization of `W`), a matrix of size `m × k` (if
-  `do_whiten` is true), or a matrix of size `m × k`. Here `m` is the number of components
-  (columns) of the input.
+- `winit::Union{Nothing,Matrix{<:Real}}=nothing`: Initial guess for the unmixing matrix 
+    `W`: either an empty matrix (for random initialization of `W`), a matrix of size 
+    `m × k` (if `do_whiten` is true), or a matrix of size `m × k`. Here `m` is the number 
+    of components (columns) of the input.
 
 # Operations
 
-- `transform(mach, Xnew)`: Return the component-separated version of input
-  `Xnew`, which should have the same scitype as `X` above.
+- `transform(mach, Xnew)`: Return the component-separated version of input `Xnew`, which 
+    should have the same scitype as `X` above.
 
 # Fitted parameters
 
@@ -540,7 +544,8 @@ The fields of `fitted_params(mach)` are:
 
 The fields of `report(mach)` are:
 
-- `indim`: Dimension (number of columns) of the training data and new data to be transformed.
+- `indim`: Dimension (number of columns) of the training data and new data to be 
+    transformed.
 
 - `outdim`: Dimension of transformed data.
 
@@ -593,9 +598,9 @@ ICA
 $(MMI.doc_header(FactorAnalysis))
 
 Factor analysis is a linear-Gaussian latent variable model that is closely related to
-probabilistic PCA. In contrast to the probabilistic PCA model, the covariance of conditional
-distribution of the observed variable given the latent variable is diagonal rather than
-isotropic.
+probabilistic PCA. In contrast to the probabilistic PCA model, the covariance of 
+conditional distribution of the observed variable given the latent variable is diagonal 
+rather than isotropic.
 
 # Training data
 
@@ -606,7 +611,7 @@ In MLJ or MLJBase, bind an instance `model` to data with
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns
-  are of scitype `Continuous`; check column scitypes with `schema(X)`.
+    are of scitype `Continuous`; check column scitypes with `schema(X)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -615,8 +620,8 @@ Train the machine using `fit!(mach, rows=...)`.
 - `method::Symbol=:cm`: Method to use to solve the problem, one of `:ml`, `:em`, `:bayes`.
 
 - `maxoutdim=0`: Controls the the dimension (number of columns) of the output,
-  `outdim`. Specifically, `outdim = min(n, indim, maxoutdim)`, where `n` is the number of
-  observations and `indim` the input dimension.
+    `outdim`. Specifically, `outdim = min(n, indim, maxoutdim)`, where `n` is the number of
+    observations and `indim` the input dimension.
 
 - `maxiter::Int=1000`: Maximum number of iterations.
 
@@ -625,35 +630,36 @@ Train the machine using `fit!(mach, rows=...)`.
 - `eta::Real=tol`: Variance lower bound.
 
 - `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: If `nothing`, centering will be
-  computed and applied; if set to `0` no centering is applied (data is assumed
-  pre-centered); if a vector, the centering is done with that vector.
+    computed and applied; if set to `0` no centering is applied (data is assumed
+    pre-centered); if a vector, the centering is done with that vector.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-  should have the same scitype as `X` above.
+    should have the same scitype as `X` above.
 
 - `inverse_transform(mach, Xsmall)`: For a dimension-reduced table `Xsmall`,
-  such as returned by `transform`, reconstruct a table, having same the number
-  of columns as the original training data `X`, that transforms to `Xsmall`.
-  Mathematically, `inverse_transform` is a right-inverse for the PCA projection
-  map, whose image is orthogonal to the kernel of that map. In particular, if
-  `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
-  only an approximation to `Xnew`.
+    such as returned by `transform`, reconstruct a table, having same the number
+    of columns as the original training data `X`, that transforms to `Xsmall`.
+    Mathematically, `inverse_transform` is a right-inverse for the PCA projection
+    map, whose image is orthogonal to the kernel of that map. In particular, if
+    `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
+    only an approximation to `Xnew`.
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
 - `projection`: Returns the projection matrix, which has size `(indim, outdim)`, where
-  `indim` and `outdim` are the number of features of the input and ouput respectively.
-  Each column of the projection matrix corresponds to a factor.
+    `indim` and `outdim` are the number of features of the input and ouput respectively.
+    Each column of the projection matrix corresponds to a factor.
 
 # Report
 
 The fields of `report(mach)` are:
 
-- `indim`: Dimension (number of columns) of the training data and new data to be transformed.
+- `indim`: Dimension (number of columns) of the training data and new data to be 
+    transformed.
 
 - `outdim`: Dimension of transformed data (number of factors).
 
@@ -706,59 +712,61 @@ In MLJ or MLJBase, bind an instance `model` to data with
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype
-  `Continuous`; check column scitypes with `schema(X)`.
+    `Continuous`; check column scitypes with `schema(X)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
 - `maxoutdim=0`: Controls the the dimension (number of columns) of the output,
-  `outdim`. Specifically, `outdim = min(n, indim, maxoutdim)`, where `n` is the number of
-  observations and `indim` the input dimension.
+    `outdim`. Specifically, `outdim = min(n, indim, maxoutdim)`, where `n` is the number of
+    observations and `indim` the input dimension.
 
 - `method::Symbol=:ml`: The method to use to solve the problem, one of `:ml`, `:em`,
-  `:bayes`.
+    `:bayes`.
 
 - `maxiter::Int=1000`: The maximum number of iterations.
 
 - `tol::Real=1e-6`: The convergence tolerance.
 
 - `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: If `nothing`, centering will be
-  computed and applied; if set to `0` no centering is applied (data is assumed
-  pre-centered); if a vector, the centering is done with that vector.
+    computed and applied; if set to `0` no centering is applied (data is assumed
+    pre-centered); if a vector, the centering is done with that vector.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-  should have the same scitype as `X` above.
+    should have the same scitype as `X` above.
 
 - `inverse_transform(mach, Xsmall)`: For a dimension-reduced table `Xsmall`,
-  such as returned by `transform`, reconstruct a table, having same the number
-  of columns as the original training data `X`, that transforms to `Xsmall`.
-  Mathematically, `inverse_transform` is a right-inverse for the PCA projection
-  map, whose image is orthogonal to the kernel of that map. In particular, if
-  `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
-  only an approximation to `Xnew`.
+    such as returned by `transform`, reconstruct a table, having same the number
+    of columns as the original training data `X`, that transforms to `Xsmall`.
+    Mathematically, `inverse_transform` is a right-inverse for the PCA projection
+    map, whose image is orthogonal to the kernel of that map. In particular, if
+    `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
+    only an approximation to `Xnew`.
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
 - `projection`: Returns the projection matrix, which has size `(indim, outdim)`, where
-  `indim` and `outdim` are the number of features of the input and ouput respectively.
-  Each column of the projection matrix corresponds to a principal component.
+    `indim` and `outdim` are the number of features of the input and ouput respectively.
+    Each column of the projection matrix corresponds to a principal component.
 
 # Report
 
 The fields of `report(mach)` are:
 
-- `indim`: Dimension (number of columns) of the training data and new data to be transformed.
+- `indim`: Dimension (number of columns) of the training data and new data to be 
+    transformed.
+
 - `outdim`: Dimension of transformed data.
 
 - `tvat`: The variance of the components.
 
-- `loadings`: The models loadings, weights for each variable used when calculating principal
-  components.
+- `loadings`: The models loadings, weights for each variable used when calculating 
+    principal components.
 
 # Examples
 

--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -303,11 +303,11 @@ Train the machine using `fit!(mach, rows=...)`.
 # Hyper-parameters
 
 - `maxoutdim=0`: Together with `variance_ratio`, controls the output dimension `outdim`
-   chosen by the model. Specifically, suppose that `k` is the smallest integer such that
-   retaining the `k` most significant principal components accounts for `variance_ratio` of
-   the total variance in the training data. Then `outdim = min(outdim, maxoutdim)`. If
-   `maxoutdim=0` (default) then the effective `maxoutdim` is `min(n, indim - 1)` where `n`
-   is the number of observations and `indim` the number of features in the training data.
+  chosen by the model. Specifically, suppose that `k` is the smallest integer such that
+  retaining the `k` most significant principal components accounts for `variance_ratio` of
+  the total variance in the training data. Then `outdim = min(outdim, maxoutdim)`. If
+  `maxoutdim=0` (default) then the effective `maxoutdim` is `min(n, indim - 1)` where `n`
+  is the number of observations and `indim` the number of features in the training data.
 
 - `variance_ratio::Float64=0.99`: The ratio of variance preserved after the transformation
 
@@ -321,38 +321,38 @@ Train the machine using `fit!(mach, rows=...)`.
       dimension and otherwise use `:svd`
 
 - `mean=nothing`: if `nothing`, centering will be computed and applied, if set to `0` no
-    centering (data is assumed pre-centered); if a vector is passed, the centering is done
-    with that vector.
+  centering (data is assumed pre-centered); if a vector is passed, the centering is done
+  with that vector.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-    should have the same scitype as `X` above.
+  should have the same scitype as `X` above.
 
 - `inverse_transform(mach, Xsmall)`: For a dimension-reduced table `Xsmall`,
-    such as returned by `transform`, reconstruct a table, having same the number
-    of columns as the original training data `X`, that transforms to `Xsmall`.
-    Mathematically, `inverse_transform` is a right-inverse for the PCA projection
-    map, whose image is orthogonal to the kernel of that map. In particular, if
-    `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
-    only an approximation to `Xnew`.
+  such as returned by `transform`, reconstruct a table, having same the number
+  of columns as the original training data `X`, that transforms to `Xsmall`.
+  Mathematically, `inverse_transform` is a right-inverse for the PCA projection
+  map, whose image is orthogonal to the kernel of that map. In particular, if
+  `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
+  only an approximation to `Xnew`.
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
 - `projection`: Returns the projection matrix, which has size `(indim, outdim)`, where
-    `indim` and `outdim` are the number of features of the input and output respectively.
+  `indim` and `outdim` are the number of features of the input and output respectively.
 
 # Report
 
 The fields of `report(mach)` are:
 
 - `indim`: Dimension (number of columns) of the training data and new data to be 
-    transformed.
+  transformed.
 
 - `outdim = min(n, indim, maxoutdim)` is the output dimension; here `n` is the number of
-    observations.
+  observations.
 
 - `tprincipalvar`: Total variance of the principal components.
 
@@ -408,19 +408,19 @@ Train the machine using `fit!(mach, rows=...)`.
 # Hyper-parameters
 
 - `maxoutdim=0`: Controls the the dimension (number of columns) of the output,
-    `outdim`. Specifically, `outdim = min(n, indim, maxoutdim)`, where `n` is the number of
-    observations and `indim` the input dimension.
+  `outdim`. Specifically, `outdim = min(n, indim, maxoutdim)`, where `n` is the number of
+  observations and `indim` the input dimension.
 
 - `kernel::Function=(x,y)->x'y`: The kernel function, takes in 2 vector arguments
-    x and y, returns a scalar value. Defaults to the dot product of `x` and `y`.
+  x and y, returns a scalar value. Defaults to the dot product of `x` and `y`.
 
 - `solver::Symbol=:eig`: solver to use for the eigenvalues, one of `:eig`(default, uses
-    `LinearAlgebra.eigen`), `:eigs`(uses `Arpack.eigs`).
+  `LinearAlgebra.eigen`), `:eigs`(uses `Arpack.eigs`).
 
 - `inverse::Bool=true`: perform calculations needed for inverse transform
 
 - `beta::Real=1.0`: strength of the ridge regression that learns the inverse transform
-    when inverse is true.
+  when inverse is true.
 
 - `tol::Real=0.0`: Convergence tolerance for eigenvalue solver.
 
@@ -432,26 +432,26 @@ Train the machine using `fit!(mach, rows=...)`.
     should have the same scitype as `X` above.
 
 - `inverse_transform(mach, Xsmall)`: For a dimension-reduced table `Xsmall`, such as
-    returned by `transform`, reconstruct a table, having same the number of columns as the
-    original training data `X`, that transforms to `Xsmall`.  Mathematically,
-    `inverse_transform` is a right-inverse for the PCA projection map, whose image is
-    orthogonal to the kernel of that map. In particular, if 
-    `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is only an 
-    approximation to `Xnew`.
+  returned by `transform`, reconstruct a table, having same the number of columns as the
+  original training data `X`, that transforms to `Xsmall`.  Mathematically,
+  `inverse_transform` is a right-inverse for the PCA projection map, whose image is
+  orthogonal to the kernel of that map. In particular, if 
+  `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is only an 
+  approximation to `Xnew`.
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
 - `projection`: Returns the projection matrix, which has size `(indim, outdim)`, where
-    `indim` and `outdim` are the number of features of the input and ouput respectively.
+  `indim` and `outdim` are the number of features of the input and ouput respectively.
 
 # Report
 
 The fields of `report(mach)` are:
 
 - `indim`: Dimension (number of columns) of the training data and new data to be
-    transformed.
+  transformed.
 
 - `outdim`: Dimension of transformed data.
 
@@ -498,17 +498,17 @@ In MLJ or MLJBase, bind an instance `model` to data with
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype
-    `Continuous`; check column scitypes with `schema(X)`.
+  `Continuous`; check column scitypes with `schema(X)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
 - `outdim::Int=0`: The number of independent components to recover, set automatically 
-    if `0`.
+  if `0`.
 
 - `alg::Symbol=:fastica`: The algorithm to use (only `:fastica` is supported at the 
-    moment).
+  moment).
 
 - `fun::Symbol=:tanh`: The approximate neg-entropy function, one of `:tanh`, `:gaus`.
 
@@ -519,18 +519,18 @@ Train the machine using `fit!(mach, rows=...)`.
 - `tol::Real=1e-6`: The convergence tolerance for change in the unmixing matrix W.
 
 - `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: mean to use, if nothing (default)
-    centering is computed and applied, if zero, no centering; otherwise a vector of means 
-    can be passed.
+  centering is computed and applied, if zero, no centering; otherwise a vector of means 
+  can be passed.
 
 - `winit::Union{Nothing,Matrix{<:Real}}=nothing`: Initial guess for the unmixing matrix 
-    `W`: either an empty matrix (for random initialization of `W`), a matrix of size 
-    `m × k` (if `do_whiten` is true), or a matrix of size `m × k`. Here `m` is the number 
-    of components (columns) of the input.
+  `W`: either an empty matrix (for random initialization of `W`), a matrix of size 
+  `m × k` (if `do_whiten` is true), or a matrix of size `m × k`. Here `m` is the number 
+  of components (columns) of the input.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return the component-separated version of input `Xnew`, which 
-    should have the same scitype as `X` above.
+  should have the same scitype as `X` above.
 
 # Fitted parameters
 
@@ -545,7 +545,7 @@ The fields of `fitted_params(mach)` are:
 The fields of `report(mach)` are:
 
 - `indim`: Dimension (number of columns) of the training data and new data to be 
-    transformed.
+  transformed.
 
 - `outdim`: Dimension of transformed data.
 
@@ -636,30 +636,30 @@ Train the machine using `fit!(mach, rows=...)`.
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-    should have the same scitype as `X` above.
+  should have the same scitype as `X` above.
 
 - `inverse_transform(mach, Xsmall)`: For a dimension-reduced table `Xsmall`,
-    such as returned by `transform`, reconstruct a table, having same the number
-    of columns as the original training data `X`, that transforms to `Xsmall`.
-    Mathematically, `inverse_transform` is a right-inverse for the PCA projection
-    map, whose image is orthogonal to the kernel of that map. In particular, if
-    `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
-    only an approximation to `Xnew`.
+  such as returned by `transform`, reconstruct a table, having same the number
+  of columns as the original training data `X`, that transforms to `Xsmall`.
+  Mathematically, `inverse_transform` is a right-inverse for the PCA projection
+  map, whose image is orthogonal to the kernel of that map. In particular, if
+  `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
+  only an approximation to `Xnew`.
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
 - `projection`: Returns the projection matrix, which has size `(indim, outdim)`, where
-    `indim` and `outdim` are the number of features of the input and ouput respectively.
-    Each column of the projection matrix corresponds to a factor.
+  `indim` and `outdim` are the number of features of the input and ouput respectively.
+  Each column of the projection matrix corresponds to a factor.
 
 # Report
 
 The fields of `report(mach)` are:
 
 - `indim`: Dimension (number of columns) of the training data and new data to be 
-    transformed.
+  transformed.
 
 - `outdim`: Dimension of transformed data (number of factors).
 
@@ -712,61 +712,61 @@ In MLJ or MLJBase, bind an instance `model` to data with
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype
-    `Continuous`; check column scitypes with `schema(X)`.
+  `Continuous`; check column scitypes with `schema(X)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
 - `maxoutdim=0`: Controls the the dimension (number of columns) of the output,
-    `outdim`. Specifically, `outdim = min(n, indim, maxoutdim)`, where `n` is the number of
-    observations and `indim` the input dimension.
+  `outdim`. Specifically, `outdim = min(n, indim, maxoutdim)`, where `n` is the number of
+  observations and `indim` the input dimension.
 
 - `method::Symbol=:ml`: The method to use to solve the problem, one of `:ml`, `:em`,
-    `:bayes`.
+  `:bayes`.
 
 - `maxiter::Int=1000`: The maximum number of iterations.
 
 - `tol::Real=1e-6`: The convergence tolerance.
 
 - `mean::Union{Nothing, Real, Vector{Float64}}=nothing`: If `nothing`, centering will be
-    computed and applied; if set to `0` no centering is applied (data is assumed
-    pre-centered); if a vector, the centering is done with that vector.
+  computed and applied; if set to `0` no centering is applied (data is assumed
+  pre-centered); if a vector, the centering is done with that vector.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-    should have the same scitype as `X` above.
+  should have the same scitype as `X` above.
 
 - `inverse_transform(mach, Xsmall)`: For a dimension-reduced table `Xsmall`,
-    such as returned by `transform`, reconstruct a table, having same the number
-    of columns as the original training data `X`, that transforms to `Xsmall`.
-    Mathematically, `inverse_transform` is a right-inverse for the PCA projection
-    map, whose image is orthogonal to the kernel of that map. In particular, if
-    `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is
-    only an approximation to `Xnew`.
+  such as returned by `transform`, reconstruct a table, having same the number
+  of columns as the original training data `X`, that transforms to `Xsmall`.
+  Mathematically, `inverse_transform` is a right-inverse for the PCA projection
+  map, whose image is orthogonal to the kernel of that map. In particular, if
+  `Xsmall = transform(mach, Xnew)`, then `inverse_transform(Xsmall)` is only an 
+  approximation to `Xnew`.
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
 - `projection`: Returns the projection matrix, which has size `(indim, outdim)`, where
-    `indim` and `outdim` are the number of features of the input and ouput respectively.
-    Each column of the projection matrix corresponds to a principal component.
+  `indim` and `outdim` are the number of features of the input and ouput respectively.
+  Each column of the projection matrix corresponds to a principal component.
 
 # Report
 
 The fields of `report(mach)` are:
 
 - `indim`: Dimension (number of columns) of the training data and new data to be 
-    transformed.
+  transformed.
 
 - `outdim`: Dimension of transformed data.
 
 - `tvat`: The variance of the components.
 
 - `loadings`: The models loadings, weights for each variable used when calculating 
-    principal components.
+  principal components.
 
 # Examples
 

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -20,106 +20,106 @@ const ERR_LONE_TARGET_CLASS = ArgumentError(
 )
 
 function _check_lda_data(model, X, y)
-  pool = MMI.classes(y[1]) # Class list containing entries in pool of y.
-  classes_seen = unique(y) # Class list of actual entries in seen in y.
-  nc = length(classes_seen) # Number of classes in pool of y.
+    pool = MMI.classes(y[1]) # Class list containing entries in pool of y.
+    classes_seen = unique(y) # Class list of actual entries in seen in y.
+    nc = length(classes_seen) # Number of classes in pool of y.
 
-  Xm_t = _matrix_transpose(model, X) # Now p x n matrix
-  p, n = size(Xm_t)
+    Xm_t = _matrix_transpose(model, X) # Now p x n matrix
+    p, n = size(Xm_t)
 
-  # Check to make sure we have more than one class in training sample.
-  # This is to prevent Sb from being a zero matrix
-  # see issue #41
-  lone_class_unsupported = model isa Union{LDA, BayesianLDA} &&
+    # Check to make sure we have more than one class in training sample.
+    # This is to prevent Sb from being a zero matrix
+    # see issue #41
+    lone_class_unsupported = model isa Union{LDA, BayesianLDA} &&
         model.cov_b != MS.SimpleCovariance()
-  if nc <= 1 && lone_class_unsupported
-      throw(ERR_LONE_TARGET_CLASS)
-  end
+    if nc <= 1 && lone_class_unsupported
+        throw(ERR_LONE_TARGET_CLASS)
+    end
 
-  # Check to make sure we have more samples than classes.
-  # This is to prevent Sw from being the zero matrix.
-  if n <= nc
-      throw(
-          ArgumentError(
-              "The number of training samples `n` has"*
-              " to be greater than number of unique classes `nc`."
-          )
-      )
-  end
-  # Check output dimension default is min(p, nc-1)
-  def_outdim = min(p, nc - 1)
-  # If unset (0) use the default; otherwise try to use the provided one
-  outdim = ifelse(model.outdim == 0, def_outdim, model.outdim)
-  # Check if the given one is sensible
-  if outdim > def_outdim
-      throw(
-          ArgumentError(
-              "`outdim` must not be larger than `min(p, nc-1)`"*
-              "where `p` is the number of features in `X` and"*
-              "`nc` is the number of unique classes in the target vector."
-          )
-      )
-  end
-  return Xm_t, y, classes_seen, pool, p, n, nc, outdim
+    # Check to make sure we have more samples than classes.
+    # This is to prevent Sw from being the zero matrix.
+    if n <= nc
+        throw(
+            ArgumentError(
+                "The number of training samples `n` has"*
+                " to be greater than number of unique classes `nc`."
+            )
+        )
+    end
+    # Check output dimension default is min(p, nc-1)
+    def_outdim = min(p, nc - 1)
+    # If unset (0) use the default; otherwise try to use the provided one
+    outdim = ifelse(model.outdim == 0, def_outdim, model.outdim)
+    # Check if the given one is sensible
+    if outdim > def_outdim
+        throw(
+            ArgumentError(
+                "`outdim` must not be larger than `min(p, nc-1)`"*
+                "where `p` is the number of features in `X` and"*
+                "`nc` is the number of unique classes in the target vector."
+            )
+        )
+    end
+    return Xm_t, y, classes_seen, pool, p, n, nc, outdim
 end
 
 function MMI.fit(model::LDA, ::Int, X, y)
-  Xm_t, _ , classes_seen, pool, _, _, nc, outdim =
-      _check_lda_data(model, X, y)
-  core_res = MS.fit(
-      MS.MulticlassLDA, Xm_t, y;
-      method=model.method,
-      outdim,
-      regcoef=model.regcoef,
-      covestimator_within=model.cov_w,
-      covestimator_between=model.cov_b
-  )
-  cache = nothing
-  report = (
-      indim = MS.size(core_res)[1],
-      outdim=MS.size(core_res)[2],
-      mean=MS.mean(core_res),
-      nclasses=nc,
-      class_means=MS.classmeans(core_res),
-      class_weights=MS.classweights(core_res),
-      Sb=MS.betweenclass_scatter(core_res),
-      Sw=MS.withclass_scatter(core_res)
-  )
-  fitresult = (core_res, classes_seen, pool)
-  return fitresult, cache, report
+    Xm_t, _ , classes_seen, pool, _, _, nc, outdim =
+        _check_lda_data(model, X, y)
+    core_res = MS.fit(
+        MS.MulticlassLDA, Xm_t, y;
+        method=model.method,
+        outdim,
+        regcoef=model.regcoef,
+        covestimator_within=model.cov_w,
+        covestimator_between=model.cov_b
+    )
+    cache = nothing
+    report = (
+        indim = MS.size(core_res)[1],
+        outdim=MS.size(core_res)[2],
+        mean=MS.mean(core_res),
+        nclasses=nc,
+        class_means=MS.classmeans(core_res),
+        class_weights=MS.classweights(core_res),
+        Sb=MS.betweenclass_scatter(core_res),
+        Sw=MS.withclass_scatter(core_res)
+    )
+    fitresult = (core_res, classes_seen, pool)
+    return fitresult, cache, report
 end
 
 function MMI.fitted_params(::LDA, (core_res, classes_seen, _))
-  return (
-      classes = classes_seen,
-      projection_matrix=MS.projection(core_res)
-  )
+    return (
+        classes = classes_seen,
+        projection_matrix=MS.projection(core_res)
+    )
 end
 
 function MMI.predict(m::LDA, (core_res, classes_seen, pool), Xnew)
-  # projection of Xnew, XWt is nt x o  where o = number of out dims
-  # nt = number ot test samples
-  XWt = MMI.matrix(Xnew) * MS.projection(core_res)
-  # centroids in the transformed space, nc x o
-  centroids = transpose(core_res.pmeans)
+    # projection of Xnew, XWt is nt x o  where o = number of out dims
+    # nt = number ot test samples
+    XWt = MMI.matrix(Xnew) * MS.projection(core_res)
+    # centroids in the transformed space, nc x o
+    centroids = transpose(core_res.pmeans)
 
-  # compute the distances in the transformed space between pairs of rows
-  # the probability matrix Pr is `n x nc` and normalised accross rows
-  Pr = pairwise(m.dist, XWt, centroids, dims=1)
-  Pr .*= -1
-  # apply a softmax transformation
-  softmax!(Pr)
-  return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
+    # compute the distances in the transformed space between pairs of rows
+    # the probability matrix Pr is `n x nc` and normalised accross rows
+    Pr = pairwise(m.dist, XWt, centroids, dims=1)
+    Pr .*= -1
+    # apply a softmax transformation
+    softmax!(Pr)
+    return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
 end
 
 metadata_model(
-  LDA,
-  human_name="linear discriminant analysis model",
-  input=Table(Continuous),
-  target=AbstractVector{<:Finite},
-  weights=false,
-  output=Table(Continuous),
-  path="$(PKG).LDA"
+    LDA,
+    human_name="linear discriminant analysis model",
+    input=Table(Continuous),
+    target=AbstractVector{<:Finite},
+    weights=false,
+    output=Table(Continuous),
+    path="$(PKG).LDA"
 )
 
 
@@ -128,153 +128,157 @@ metadata_model(
 ####
 
 @mlj_model mutable struct BayesianLDA <: MMI.Probabilistic
-  method::Symbol = :gevd::(_ in (:gevd, :whiten))
-  cov_w::CovarianceEstimator=MS.SimpleCovariance()
-  cov_b::CovarianceEstimator=MS.SimpleCovariance()
-  outdim::Int=0::(_ ≥ 0)
-  regcoef::Float64=1e-6::(_ ≥ 0)
-  priors::Union{
-    Nothing, 
-    UnivariateFinite{<:Any, <:Any, <:Any, <:Real},
-    Dict{<:Any, <:Real}
-  }=nothing
+    method::Symbol = :gevd::(_ in (:gevd, :whiten))
+    cov_w::CovarianceEstimator=MS.SimpleCovariance()
+    cov_b::CovarianceEstimator=MS.SimpleCovariance()
+    outdim::Int=0::(_ ≥ 0)
+    regcoef::Float64=1e-6::(_ ≥ 0)
+    priors::Union{
+        Nothing, 
+        UnivariateFinite{<:Any, <:Any, <:Any, <:Real},
+        Dict{<:Any, <:Real}
+    }=nothing
 end
 
 function _matrix_transpose(::Union{LDA,BayesianLDA}, X)
-  # MultivariateStats 9.0 is not supporting adjoints
-  return MMI.matrix(X, transpose=true)
+    # MultivariateStats 9.0 is not supporting adjoints
+    return MMI.matrix(X, transpose=true)
 end
 
 function _check_prob01(priors)
-  # `priors` is esssentially always an instance of type `Vector{<:Real}`.
-  # The next two conditions implicitly checks that
-  # ` 0 .<= priors .<= 1` and `sum(priors) ≈ 1` are true.
-  if any(<(0), priors)
-    throw(ArgumentError("probabilities specified in `priors` must non-negative"))
-  end
+    # `priors` is esssentially always an instance of type `Vector{<:Real}`.
+    # The next two conditions implicitly checks that
+    # ` 0 .<= priors .<= 1` and `sum(priors) ≈ 1` are true.
+    if any(<(0), priors)
+        throw(ArgumentError("probabilities specified in `priors` must non-negative"))
+    end
 
-  if !isapprox(sum(priors), 1)
-    throw(ArgumentError("probabilities specified in `priors` must sum to 1"))
-  end
-  return nothing
+    if !isapprox(sum(priors), 1)
+        throw(ArgumentError("probabilities specified in `priors` must sum to 1"))
+    end
+    return nothing
 end
 
 @inline function _check_lda_priors(priors::UnivariateFinite, classes_seen, pool)
-  if MMI.classes(priors) != pool
-      throw(
-        ArgumentError("UnivariateFinite `priors` must have common pool with training target.")
-      )
-  end
-  priors_ = pdf.(priors, support(priors))
-  _check_prob01(priors_)
-  # Select priors for unique classes in `y` (For resampling purposes).
-  return pdf.(priors, classes_seen)
+    if MMI.classes(priors) != pool
+        throw(
+            ArgumentError(
+                "UnivariateFinite `priors` must have common pool with training target."
+            )
+        )
+    end
+    priors_ = pdf.(priors, support(priors))
+    _check_prob01(priors_)
+    # Select priors for unique classes in `y` (For resampling purposes).
+    return pdf.(priors, classes_seen)
 end
 
 @inline function _check_lda_priors(priors::Dict{K, V}, classes_seen, pool) where {K, V}
-  if !all(in(pool), keys(priors))
-      throw(
-        ArgumentError("keys used in `priors` dictionary must be in pool of training target.")
-      )
-  end
-  _check_prob01(values(priors))
-  # Select priors for unique classes in `y` (For resampling purporses).
-  priors_ = get.(Ref(priors), classes_seen, V(0))
-  return priors_
+    if !all(in(pool), keys(priors))
+        throw(
+            ArgumentError(
+                "keys used in `priors` dictionary must be in pool of training target."
+            )
+        )
+    end
+    _check_prob01(values(priors))
+    # Select priors for unique classes in `y` (For resampling purporses).
+    priors_ = get.(Ref(priors), classes_seen, V(0))
+    return priors_
 end
 
 _check_lda_priors(priors::Nothing, classes_seen, pool) = nothing
 
 function MMI.fit(model::BayesianLDA, ::Int, X, y)
-  Xm_t, _, classes_seen, pool, _, n, nc, outdim =
-      _check_lda_data(model, X, y)
-  ## If piors are specified check if they makes sense.
-  ## This was put here to through errors much earlier
-  priors_ = _check_lda_priors(model.priors, classes_seen, pool)
+    Xm_t, _, classes_seen, pool, _, n, nc, outdim =
+        _check_lda_data(model, X, y)
+    ## If piors are specified check if they makes sense.
+    ## This was put here to through errors much earlier
+    priors_ = _check_lda_priors(model.priors, classes_seen, pool)
 
-  core_res = MS.fit(
-      MS.MulticlassLDA, Xm_t, y;
-      method=model.method,
-      outdim,
-      regcoef=model.regcoef,
-      covestimator_within=model.cov_w,
-      covestimator_between=model.cov_b
-  )
+    core_res = MS.fit(
+        MS.MulticlassLDA, Xm_t, y;
+        method=model.method,
+        outdim,
+        regcoef=model.regcoef,
+        covestimator_within=model.cov_w,
+        covestimator_between=model.cov_b
+    )
 
-  ## Estimates prior probabilities if specified by user.
-  ## Put it here to avoid recomputing as the fitting process does this already
-  if priors_ === nothing
-      weights = MS.classweights(core_res)
-      total = core_res.stats.tweight
-      priors = weights ./ total
-  else
-      priors = priors_
-  end
+    ## Estimates prior probabilities if specified by user.
+    ## Put it here to avoid recomputing as the fitting process does this already
+    if priors_ === nothing
+        weights = MS.classweights(core_res)
+        total = core_res.stats.tweight
+        priors = weights ./ total
+    else
+        priors = priors_
+    end
 
-  cache = nothing
-  report = (
-      classes=classes_seen,
-      indim = MS.size(core_res)[1],
-      outdim=MS.size(core_res)[2],
-      mean=MS.mean(core_res),
-      nclasses=nc,
-      class_means=MS.classmeans(core_res),
-      class_weights=MS.classweights(core_res),
-      Sb=MS.betweenclass_scatter(core_res),
-      Sw=MS.withclass_scatter(core_res)
-  )
+    cache = nothing
+    report = (
+        classes=classes_seen,
+        indim = MS.size(core_res)[1],
+        outdim=MS.size(core_res)[2],
+        mean=MS.mean(core_res),
+        nclasses=nc,
+        class_means=MS.classmeans(core_res),
+        class_weights=MS.classweights(core_res),
+        Sb=MS.betweenclass_scatter(core_res),
+        Sw=MS.withclass_scatter(core_res)
+    )
 
-  fitresult = (core_res, classes_seen, pool, priors, n)
-  return fitresult, cache, report
+    fitresult = (core_res, classes_seen, pool, priors, n)
+    return fitresult, cache, report
 end
 
 function MMI.fitted_params(::BayesianLDA, (core_res, classes_seen, pool,  priors, _))
- return (
-     classes = classes_seen,
-     projection_matrix=MS.projection(core_res),
-     priors=MMI.UnivariateFinite(classes_seen, priors, pool=pool)
-  )
+    return (
+        classes = classes_seen,
+        projection_matrix=MS.projection(core_res),
+        priors=MMI.UnivariateFinite(classes_seen, priors, pool=pool)
+    )
 end
 
 function MMI.predict(m::BayesianLDA, (core_res, classes_seen, pool, priors, n), Xnew)
-   # projection of Xnew, XWt is nt x o  where o = number of out dims
-  # nt = number ot test samples
-  XWt = MMI.matrix(Xnew) * core_res.proj
-  # centroids in the transformed space, nc x o
-  centroids = transpose(core_res.pmeans)
+    # projection of Xnew, XWt is nt x o  where o = number of out dims
+    # nt = number ot test samples
+    XWt = MMI.matrix(Xnew) * core_res.proj
+    # centroids in the transformed space, nc x o
+    centroids = transpose(core_res.pmeans)
 
-  # The discriminant matrix `Pr` is of dimension `nt x nc`
-  # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σw⁻¹)(xᵢ −  µₖ) + log(priorsₖ) where (Σw = Sw/n)
-  # In the transformed space this becomes
-  # Pr[i,k] = -0.5*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(PᵀΣw⁻¹P)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
-  # But PᵀSw⁻¹P = I and PᵀΣw⁻¹P = n*I due to the nature of the projection_matrix, P
-  # Giving Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
-  # with (Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) being the SquaredEquclidean distance between
-  # pairs of rows in the transformed space
-  Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
-  Pr .*= (-n/2)
-  Pr .+= log.(transpose(priors))
+    # The discriminant matrix `Pr` is of dimension `nt x nc`
+    # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σw⁻¹)(xᵢ −  µₖ) + log(priorsₖ) where (Σw = Sw/n)
+    # In the transformed space this becomes
+    # Pr[i,k] = -0.5*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(PᵀΣw⁻¹P)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
+    # But PᵀSw⁻¹P = I and PᵀΣw⁻¹P = n*I due to the nature of the projection_matrix, P
+    # Giving Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
+    # with (Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) being the SquaredEquclidean distance between
+    # pairs of rows in the transformed space
+    Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
+    Pr .*= (-n/2)
+    Pr .+= log.(transpose(priors))
 
-  # apply a softmax transformation to convert Pr to a probability matrix
-  softmax!(Pr)
-  return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
+    # apply a softmax transformation to convert Pr to a probability matrix
+    softmax!(Pr)
+    return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
 end
 
 function MMI.transform(m::T, (core_res, ), X) where T<:Union{LDA, BayesianLDA}
-  # projection of X, XWt is nt x o  where o = out dims
-  proj = MS.projection(core_res) #proj is the projection_matrix
-  XWt = MMI.matrix(X) * proj
-  return MMI.table(XWt, prototype = X)
+    # projection of X, XWt is nt x o  where o = out dims
+    proj = MS.projection(core_res) #proj is the projection_matrix
+    XWt = MMI.matrix(X) * proj
+    return MMI.table(XWt, prototype = X)
 end
 
 metadata_model(
-  BayesianLDA,
-  human_name="Bayesian LDA model",
-  input=Table(Continuous),
-  target= AbstractVector{<:Finite},
-  weights=false,
-  output=Table(Continuous),
-  path="$(PKG).BayesianLDA"
+    BayesianLDA,
+    human_name="Bayesian LDA model",
+    input=Table(Continuous),
+    target= AbstractVector{<:Finite},
+    weights=false,
+    output=Table(Continuous),
+    path="$(PKG).BayesianLDA"
 )
 
 ####
@@ -282,84 +286,84 @@ metadata_model(
 ####
 
 @mlj_model mutable struct SubspaceLDA <: MMI.Probabilistic
-  normalize::Bool = true
-  outdim::Int = 0::(_ ≥ 0)
-  dist::SemiMetric = SqEuclidean()
+    normalize::Bool = true
+    outdim::Int = 0::(_ ≥ 0)
+    dist::SemiMetric = SqEuclidean()
 end
 
 function subspace_outdim(core_res, outdim)
-  # `projLDA` is a `r x min(r, nc - 1)`  where `r` is the rank of the within-class
-  # scatter matrix and `nc` is the number of classes seen in the training sample.
-  projLDA = core_res.projLDA
-  return min(size(projLDA, 2), outdim) # the same as `min(r, outdim)`
+    # `projLDA` is a `r x min(r, nc - 1)`  where `r` is the rank of the within-class
+    # scatter matrix and `nc` is the number of classes seen in the training sample.
+    projLDA = core_res.projLDA
+    return min(size(projLDA, 2), outdim) # the same as `min(r, outdim)`
 end
 
 function explained_variance(core_res)
-  # λ is a `min(r, nc -1) x 1` vector containing the eigen values sorted in descending order.
-  # where `r` is the rank of the within-class covariance matrix.
-  λ = core_res.λ
-  return λ ./ sum(λ) #proportions of variance
+    # λ is a `min(r, nc -1) x 1` vector containing the eigen values sorted in descending 
+    # order, where `r` is the rank of the within-class covariance matrix.
+    λ = core_res.λ
+    return λ ./ sum(λ) #proportions of variance
 end
 
 function MMI.fit(model::SubspaceLDA, ::Int, X, y)
-  Xm_t, _, classes_seen, pool, _, _, nc, outdim =
-      _check_lda_data(model, X, y)
+    Xm_t, _, classes_seen, pool, _, _, nc, outdim =
+        _check_lda_data(model, X, y)
 
-  core_res = MS.fit(
-      MS.SubspaceLDA, Xm_t, y;
-      normalize = model.normalize
-  )
+    core_res = MS.fit(
+        MS.SubspaceLDA, Xm_t, y;
+        normalize = model.normalize
+    )
 
-  cache = nothing
-  outdim = subspace_outdim(core_res, outdim)
-  report = (
-      indim = MS.size(core_res)[1],
-      outdim = outdim,
-      mean=MS.mean(core_res),
-      nclasses=nc,
-      class_means=MS.classmeans(core_res),
-      class_weights=MS.classweights(core_res),
-      explained_variance_ratio=explained_variance(core_res),
-  )
-  
-  fitresult = (core_res, outdim, classes_seen, pool)
-  return fitresult, cache, report
+    cache = nothing
+    outdim = subspace_outdim(core_res, outdim)
+    report = (
+        indim = MS.size(core_res)[1],
+        outdim = outdim,
+        mean=MS.mean(core_res),
+        nclasses=nc,
+        class_means=MS.classmeans(core_res),
+        class_weights=MS.classweights(core_res),
+        explained_variance_ratio=explained_variance(core_res),
+    )
+    
+    fitresult = (core_res, outdim, classes_seen, pool)
+    return fitresult, cache, report
 end
 
 function MMI.fitted_params(::SubspaceLDA, (core_res, outdim, classes_seen, _))
-  return (
-    classes=classes_seen, 
-    projection_matrix=core_res.projw * view(core_res.projLDA, :, 1:outdim)
-  )
+    return (
+        classes=classes_seen, 
+        projection_matrix=core_res.projw * view(core_res.projLDA, :, 1:outdim)
+    )
 end
 
 function MMI.predict(m::SubspaceLDA, (core_res, outdim, classes_seen, pool), Xnew)
-  # projection of `Xnew`, `XWt` is `nt x o` where `o` is the number of out dims
-  # and `nt` is the number ot test samples.
-  # `proj` is the overall projection_matrix
-  proj = core_res.projw * @view(core_res.projLDA[:, 1:outdim])
-  XWt = MMI.matrix(Xnew) * proj
+    # projection of `Xnew`, `XWt` is `nt x o` where `o` is the number of out dims
+    # and `nt` is the number ot test samples.
+    # `proj` is the overall projection_matrix
+    proj = core_res.projw * @view(core_res.projLDA[:, 1:outdim])
+    XWt = MMI.matrix(Xnew) * proj
 
-  # centroids in the transformed space, nc x o
-  centroids = transpose(core_res.cmeans) * proj
+    # centroids in the transformed space, nc x o
+    centroids = transpose(core_res.cmeans) * proj
 
-  # Compute the distances in the transformed space between pairs of rows
-  # the probability matrix is `nt x nc` and normalised accross rows
-  Pr = pairwise(m.dist, XWt, centroids, dims=1)
-  Pr .*= -1
-  # apply a softmax transformation
-  softmax!(Pr)
-  return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
+    # Compute the distances in the transformed space between pairs of rows
+    # the probability matrix is `nt x nc` and normalised accross rows
+    Pr = pairwise(m.dist, XWt, centroids, dims=1)
+    Pr .*= -1
+    # apply a softmax transformation
+    softmax!(Pr)
+    return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
 end
 
 metadata_model(
-  SubspaceLDA,
-  human_name="subpace LDA model",
-  input=Table(Continuous),
-  target=AbstractVector{<:Finite},
-  weights=false,
-  output=Table(Continuous),
-  path="$(PKG).SubspaceLDA"
+    SubspaceLDA,
+    human_name="subpace LDA model",
+    input=Table(Continuous),
+    target=AbstractVector{<:Finite},
+    weights=false,
+    output=Table(Continuous),
+    path="$(PKG).SubspaceLDA"
 )
 
 ####
@@ -367,61 +371,61 @@ metadata_model(
 ####
 
 @mlj_model mutable struct BayesianSubspaceLDA <: MMI.Probabilistic
-  normalize::Bool=false
-  outdim::Int= 0::(_ ≥ 0)
-  priors::Union{
-    Nothing, 
-    UnivariateFinite{<:Any, <:Any, <:Any, <:Real},
-    Dict{<:Any, <:Real}
-  }=nothing
+    normalize::Bool=false
+    outdim::Int= 0::(_ ≥ 0)
+    priors::Union{
+        Nothing, 
+        UnivariateFinite{<:Any, <:Any, <:Any, <:Real},
+        Dict{<:Any, <:Real}
+    }=nothing
 end
 
 function MMI.fit(model::BayesianSubspaceLDA, ::Int, X, y)
-  Xm_t, _, classes_seen, pool, _, n, nc, outdim =
-      _check_lda_data(model, X, y)
-  ## If piors are specified check if they makes sense.
-  ## This was put here to through errors much earlier
-  priors_ = _check_lda_priors(model.priors, classes_seen, pool)
+    Xm_t, _, classes_seen, pool, _, n, nc, outdim =
+        _check_lda_data(model, X, y)
+    ## If piors are specified check if they makes sense.
+    ## This was put here to through errors much earlier
+    priors_ = _check_lda_priors(model.priors, classes_seen, pool)
 
-  core_res = MS.fit(
-      MS.SubspaceLDA, Xm_t, y;
-      normalize = model.normalize
-  )
+    core_res = MS.fit(
+        MS.SubspaceLDA, Xm_t, y;
+        normalize = model.normalize
+    )
 
-  explained_variance_ratio = explained_variance(core_res)
-  mult = model.normalize ? n : 1 #used in prediction
+    explained_variance_ratio = explained_variance(core_res)
+    mult = model.normalize ? n : 1 #used in prediction
 
-  ## Estimates prior probabilities if specified by user.
-  ## Put it here to avoid recomputing as the fitting process does this already
-  if priors_ === nothing
-      weights = MS.classweights(core_res)
-      priors = weights ./ n
-  else
-      priors = priors_
-  end
+    ## Estimates prior probabilities if specified by user.
+    ## Put it here to avoid recomputing as the fitting process does this already
+    if priors_ === nothing
+        weights = MS.classweights(core_res)
+        priors = weights ./ n
+    else
+        priors = priors_
+    end
 
-  cache = nothing
-  outdim = subspace_outdim(core_res, outdim)
-  report = (
-      indim = MS.size(core_res)[1],
-      outdim = outdim,
-      mean=MS.mean(core_res),
-      nclasses=nc,
-      class_means=MS.classmeans(core_res),
-      class_weights=MS.classweights(core_res),
-      explained_variance_ratio=explained_variance(core_res),
-  )
-  
-  fitresult = (core_res, outdim, classes_seen, pool, priors, n, mult)
-  return fitresult, cache, report
+    cache = nothing
+    outdim = subspace_outdim(core_res, outdim)
+    report = (
+        indim = MS.size(core_res)[1],
+        outdim = outdim,
+        mean=MS.mean(core_res),
+        nclasses=nc,
+        class_means=MS.classmeans(core_res),
+        class_weights=MS.classweights(core_res),
+        explained_variance_ratio=explained_variance(core_res),
+    )
+    
+    fitresult = (core_res, outdim, classes_seen, pool, priors, n, mult)
+    return fitresult, cache, report
 end
 
 function _matrix_transpose(model::Union{SubspaceLDA, BayesianSubspaceLDA}, X)
-  return MMI.matrix(X)'
+    return MMI.matrix(X)'
 end
 
 function MMI.fitted_params(
-  ::BayesianSubspaceLDA, (core_res, outdim, classes_seen, pool, priors, _, _)
+    ::BayesianSubspaceLDA, (core_res, outdim, classes_seen, pool, priors, _, _)
 )
   return (
       classes = classes_seen,
@@ -431,63 +435,63 @@ function MMI.fitted_params(
 end
 
 function MMI.predict(
-  m::BayesianSubspaceLDA,
-  (core_res, outdim, classes_seen, pool, priors, n, mult),
-  Xnew
+    m::BayesianSubspaceLDA,
+    (core_res, outdim, classes_seen, pool, priors, n, mult),
+    Xnew
 )
-  # projection of `Xnew`, `XWt` is `nt x o` where `o` is the number of out dims
-  # and `nt` is the number ot test samples.
-  # `proj` is the overall projection_matrix
-  proj = core_res.projw * @view(core_res.projLDA[:, 1:outdim])
-  XWt = MMI.matrix(Xnew) * proj
+    # projection of `Xnew`, `XWt` is `nt x o` where `o` is the number of out dims
+    # and `nt` is the number ot test samples.
+    # `proj` is the overall projection_matrix
+    proj = core_res.projw * @view(core_res.projLDA[:, 1:outdim])
+    XWt = MMI.matrix(Xnew) * proj
 
-  # centroids in the transformed space, `nc x o`
-  centroids = transpose(core_res.cmeans) * proj
-  nc = length(classes_seen)
+    # centroids in the transformed space, `nc x o`
+    centroids = transpose(core_res.cmeans) * proj
+    nc = length(classes_seen)
 
-  # compute the distances in the transformed space between pairs of rows
-  # The discriminant matrix `Pr` is of dimension `nt x nc`
-  # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σ⁻¹)(xᵢ −  µₖ) + log(priorsₖ)
-  # where `Σ = Sw/(n-nc)` is the within-class covariance matrix which maybe singular,
-  # Using `P` to project to the subspace spanned by the within-class covariance matrix
-  # The discriminant matrix `Pr` becomes
-  # Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Σw⁻¹)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
-  # where `Σw = PᵀSwP/(n-nc)` is now non-singular,
-  # Applying the LDA projection, `L` in the subspace spanned by the within-class
-  # covariance matrix, this becomes
-  # Pr[i,k] = -0.5*(LᵀPᵀxᵢ −  LᵀPᵀµₖ)ᵀ(LᵀΣw⁻¹Lᵀ)(Lᵀxᵢ −  ᵀlµₖ) + log(priorsₖ)
-  # But LᵀΣw⁻¹L = ((n-nc)/mult)*I and `M = PL`
-  # Giving Pr[i,k] = -0.5*n*(Mᵀxᵢ −  Mᵀµₖ)ᵀ(Mᵀxᵢ −  Mᵀµₖ) + log(priorsₖ)
-  # where (Mᵀxᵢ −  Mᵀµₖ)ᵀ(Mᵀxᵢ −  Mᵀµₖ) is the SquaredEquclidean distance in the
-  # space spanned by the overall projection `PL`
-  Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
-  Pr .*= (-(n-nc)/2mult)
-  Pr .+= log.(transpose(priors))
+    # compute the distances in the transformed space between pairs of rows
+    # The discriminant matrix `Pr` is of dimension `nt x nc`
+    # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σ⁻¹)(xᵢ −  µₖ) + log(priorsₖ)
+    # where `Σ = Sw/(n-nc)` is the within-class covariance matrix which maybe singular,
+    # Using `P` to project to the subspace spanned by the within-class covariance matrix
+    # The discriminant matrix `Pr` becomes
+    # Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Σw⁻¹)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
+    # where `Σw = PᵀSwP/(n-nc)` is now non-singular,
+    # Applying the LDA projection, `L` in the subspace spanned by the within-class
+    # covariance matrix, this becomes
+    # Pr[i,k] = -0.5*(LᵀPᵀxᵢ −  LᵀPᵀµₖ)ᵀ(LᵀΣw⁻¹Lᵀ)(Lᵀxᵢ −  ᵀlµₖ) + log(priorsₖ)
+    # But LᵀΣw⁻¹L = ((n-nc)/mult)*I and `M = PL`
+    # Giving Pr[i,k] = -0.5*n*(Mᵀxᵢ −  Mᵀµₖ)ᵀ(Mᵀxᵢ −  Mᵀµₖ) + log(priorsₖ)
+    # where (Mᵀxᵢ −  Mᵀµₖ)ᵀ(Mᵀxᵢ −  Mᵀµₖ) is the SquaredEquclidean distance in the
+    # space spanned by the overall projection `PL`
+    Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
+    Pr .*= (-(n-nc)/2mult)
+    Pr .+= log.(transpose(priors))
 
-  # apply a softmax transformation to convert Pr to a probability matrix
-  softmax!(Pr)
-  return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
+    # apply a softmax transformation to convert Pr to a probability matrix
+    softmax!(Pr)
+    return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
 end
 
 function MMI.transform(
-  m::T, (core_res, outdim, _), X
+    m::T, (core_res, outdim, _), X
 ) where T<:Union{SubspaceLDA, BayesianSubspaceLDA}
-  # projection of `X`, `XWt` is `nt x o`  where `o` is the out dims and
-  # `nt` is the number of test cases
-  proj = core_res.projw * view(core_res.projLDA, :, 1:outdim)
-  # `proj` is overall the projection_matrix
-  XWt = MMI.matrix(X) * proj
-  return MMI.table(XWt, prototype = X)
+    # projection of `X`, `XWt` is `nt x o`  where `o` is the out dims and
+    # `nt` is the number of test cases
+    proj = core_res.projw * view(core_res.projLDA, :, 1:outdim)
+    # `proj` is overall the projection_matrix
+    XWt = MMI.matrix(X) * proj
+    return MMI.table(XWt, prototype = X)
 end
 
 metadata_model(
-  BayesianSubspaceLDA,
-  human_name="Bayesian subspace LDA model",
-  input=Table(Continuous),
-  target=AbstractVector{<:Finite},
-  weights=false,
-  output=Table(Continuous),
-  path="$(PKG).BayesianSubspaceLDA"
+    BayesianSubspaceLDA,
+    human_name="Bayesian subspace LDA model",
+    input=Table(Continuous),
+    target=AbstractVector{<:Finite},
+    weights=false,
+    output=Table(Continuous),
+    path="$(PKG).BayesianSubspaceLDA"
 )
 
 
@@ -497,34 +501,34 @@ metadata_model(
 $(MMI.doc_header(LDA))
 
 [Multiclass linear discriminant
-analysis](https://en.wikipedia.org/wiki/Linear_discriminant_analysis) learns a projection in
-a space of features to a lower dimensional space, in a way that attempts to preserve as much
-as possible the degree to which the classes of a discrete target variable can be
+analysis](https://en.wikipedia.org/wiki/Linear_discriminant_analysis) learns a projection 
+in a space of features to a lower dimensional space, in a way that attempts to preserve 
+as much as possible the degree to which the classes of a discrete target variable can be
 discriminated. This can be used either for dimension reduction of the features (see
-`transform` below) or for probabilistic classification of the target (see `predict` below).
+`transform` below) or for probabilistic classification of the target 
+(see `predict` below).
 
 In the case of prediction, the class probability for a new observation reflects the
 proximity of that observation to training observations associated with that class, and how
 far away the observation is from observations associated with other classes. Specifically,
-the distances, in the transformed (projected) space, of a new observation, from the centroid
-of each target class, is computed; the resulting vector of distances, multiplied by minus
-one, is passed to a softmax function to obtain a class probability prediction. Here
-"distance" is computed using a user-specified distance function.
+the distances, in the transformed (projected) space, of a new observation, from the 
+centroid of each target class, is computed; the resulting vector of distances, multiplied 
+by minus one, is passed to a softmax function to obtain a class probability prediction. 
+Here "distance" is computed using a user-specified distance function.
 
 # Training data
 
 In MLJ or MLJBase, bind an instance `model` to data with
 
-  mach = machine(model, X, y)
+    mach = machine(model, X, y)
 
 Here:
 
-- `X` is any table of input features (eg, a `DataFrame`) whose columns
-are of scitype `Continuous`; check column scitypes with `schema(X)`.
+- `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype 
+    `Continuous`; check column scitypes with `schema(X)`.
 
-- `y` is the target, which can be any `AbstractVector` whose element
-scitype is `OrderedFactor` or `Multiclass`; check the scitype
-with `scitype(y)`
+- `y` is the target, which can be any `AbstractVector` whose element scitype is 
+    `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -533,34 +537,35 @@ Train the machine using `fit!(mach, rows=...)`.
 - `method::Symbol=:gevd`: The solver, one of `:gevd` or `:whiten` methods.
 
 - `cov_w::StatsBase.SimpleCovariance()`: An estimator for the within-class
-covariance (used in computing the within-class scatter matrix, `Sw`). Any robust estimator
-from `CovarianceEstimation.jl` can be used.
+    covariance (used in computing the within-class scatter matrix, `Sw`). Any robust 
+    estimator from `CovarianceEstimation.jl` can be used.
 
 - `cov_b::StatsBase.SimpleCovariance()`: The same as `cov_w` but for the
-between-class covariance (used in computing the between-class scatter matrix, `Sb`).
+    between-class covariance (used in computing the between-class scatter matrix, `Sb`).
 
 - `outdim::Int=0`: The output dimension, i.e dimension of the transformed space,
-automatically set to `min(indim, nclasses-1)` if equal to 0.
+    automatically set to `min(indim, nclasses-1)` if equal to 0.
 
 - `regcoef::Float64=1e-6`: The regularization coefficient. A positive value
-`regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
-diagonal of `Sw` to improve numerical stability. This can be useful if using the standard
-covariance estimator.
+    `regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
+    diagonal of `Sw` to improve numerical stability. This can be useful if using the 
+    standard covariance estimator.
 
 - `dist=Distances.SqEuclidean()`: The distance metric to use when performing classification
-(to compare the distance between a new point and centroids in the transformed space); must
-be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., `Distances.CosineDist`.
+    (to compare the distance between a new point and centroids in the transformed space); 
+    must be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., 
+    `Distances.CosineDist`.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-should have the same scitype as `X` above.
+    should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew` having the
-same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+    same scitype as `X` above. Predictions are probabilistic but uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions returned
-above.
+    above.
 
 
 # Fitted parameters
@@ -570,8 +575,8 @@ The fields of `fitted_params(mach)` are:
 - `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
-`indim` and `outdim` are the input and output dimensions respectively (See Report 
-section below).
+    `indim` and `outdim` are the input and output dimensions respectively (See Report 
+    section below).
 
 # Report
 
@@ -584,15 +589,15 @@ The fields of `report(mach)` are:
 - `mean`: The mean of the untransformed training data. A vector of length `indim`.
 
 - `nclasses`: The number of classes directly observed in the training data (which can be
-less than the total number of classes in the class pool).
+    less than the total number of classes in the class pool).
 
 - `class_means`: The class-specific means of the training data. A matrix of size 
-`(indim, nclasses)` with the ith column being the class-mean of the ith class in 
-`classes` (See fitted params section above).
+    `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+    `classes` (See fitted params section above).
 
 - `class_weights`: The weights (class counts) of each class. A vector of length 
-`nclasses` with the ith element being the class weight of the ith class in 
-`classes`. (See fitted params section above.)
+    `nclasses` with the ith element being the class weight of the ith class in 
+    `classes`. (See fitted params section above.)
 
 - `Sb`: The between class scatter matrix.
 
@@ -641,15 +646,15 @@ Investigation](https://doi.org/10.1007/s10115-006-0013-y).
 
 In MLJ or MLJBase, bind an instance `model` to data with
 
-  mach = machine(model, X, y)
+    mach = machine(model, X, y)
 
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype
-`Continuous`; check column scitypes with `schema(X)`.
+    `Continuous`; check column scitypes with `schema(X)`.
 
 - `y` is the target, which can be any `AbstractVector` whose element scitype is
-`OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`
+    `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -658,36 +663,37 @@ Train the machine using `fit!(mach, rows=...)`.
 - `method::Symbol=:gevd`: choice of solver, one of `:gevd` or `:whiten` methods.
 
 - `cov_w::StatsBase.SimpleCovariance()`: An estimator for the within-class
-covariance (used in computing the within-class scatter matrix, `Sw`). Any robust estimator
-from `CovarianceEstimation.jl` can be used.
+    covariance (used in computing the within-class scatter matrix, `Sw`). Any robust 
+    estimator from `CovarianceEstimation.jl` can be used.
 
 - `cov_b::StatsBase.SimpleCovariance()`: The same as `cov_w` but for the
-between-class covariance (used in computing the between-class scatter matrix, `Sb`).
+    between-class covariance (used in computing the between-class scatter matrix, `Sb`).
 
 - `outdim::Int=0`: The output dimension, i.e., dimension of the transformed space,
-automatically set to `min(indim, nclasses-1)` if equal to 0.
+    automatically set to `min(indim, nclasses-1)` if equal to 0.
 
 - `regcoef::Float64=1e-6`: The regularization coefficient. A positive value
-`regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
-diagonal of `Sw` to improve numerical stability. This can be useful if using the standard
-covariance estimator.
+    `regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
+    diagonal of `Sw` to improve numerical stability. This can be useful if using the 
+    standard covariance estimator.
 
 - `priors::Union{Nothing, UnivariateFinite{<:Any, <:Any, <:Any, <:Real}, 
-Dict{<:Any, <:Real}} = nothing`: For use in prediction with Bayes rule. If `priors = nothing` 
-then `priors` are estimated from the class proportions in the training data. Otherwise it 
-requires a `Dict` or `UnivariateFinite` object specifying the classes with non-zero 
-probabilities in the training target.
+    Dict{<:Any, <:Real}} = nothing`: For use in prediction with Bayes rule. If 
+    `priors = nothing` then `priors` are estimated from the class proportions in the 
+    training data. Otherwise it requires a `Dict` or `UnivariateFinite` object specifying 
+    the classes with non-zero probabilities in the training target.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-should have the same scitype as `X` above.
+    should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew`, which
-should have the same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+    should have the same scitype as `X` above. Predictions are probabilistic but 
+    uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions returned
-above.
+    above.
 
 
 # Fitted parameters
@@ -697,11 +703,11 @@ The fields of `fitted_params(mach)` are:
 - `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
-`indim` and `outdim` are the input and output dimensions respectively (See Report 
-section below).
+    `indim` and `outdim` are the input and output dimensions respectively (See Report 
+    section below).
 
 - `priors`: The class priors for classification. As inferred from training target `y`, if
-not user-specified. A UnivariateFinite object with levels consistent with `levels(y)`.
+    not user-specified. A UnivariateFinite object with levels consistent with `levels(y)`.
 
 # Report
 
@@ -714,15 +720,15 @@ The fields of `report(mach)` are:
 - `mean`: The mean of the untransformed training data. A vector of length `indim`.
 
 - `nclasses`: The number of classes directly observed in the training data (which can be
-less than the total number of classes in the class pool).
+    less than the total number of classes in the class pool).
 
 - `class_means`: The class-specific means of the training data. A matrix of size 
-`(indim, nclasses)` with the ith column being the class-mean of the ith class in 
-`classes` (See fitted params section above).
+    `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+    `classes` (See fitted params section above).
 
 - `class_weights`: The weights (class counts) of each class. A vector of length 
-`nclasses` with the ith element being the class weight of the ith class in 
-`classes`. (See fitted params section above.)
+    `nclasses` with the ith element being the class weight of the ith class in 
+    `classes`. (See fitted params section above.)
 
 - `Sb`: The between class scatter matrix.
 
@@ -755,15 +761,15 @@ BayesianLDA
 $(MMI.doc_header(SubspaceLDA))
 
 Multiclass subspace linear discriminant analysis (LDA) is a variation on ordinary
-[`LDA`](@ref) suitable for high dimensional data, as it avoids storing scatter matrices. For
-details, refer the [MultivariateStats.jl
+[`LDA`](@ref) suitable for high dimensional data, as it avoids storing scatter matrices. 
+For details, refer the [MultivariateStats.jl
 documentation](https://juliastats.org/MultivariateStats.jl/stable/).
 
 In addition to dimension reduction (using `transform`) probabilistic classification is
 provided (using `predict`).  In the case of classification, the class probability for a new
 observation reflects the proximity of that observation to training observations associated
-with that class, and how far away the observation is from observations associated with other
-classes. Specifically, the distances, in the transformed (projected) space, of a new
+with that class, and how far away the observation is from observations associated with 
+other classes. Specifically, the distances, in the transformed (projected) space, of a new
 observation, from the centroid of each target class, is computed; the resulting vector of
 distances, multiplied by minus one, is passed to a softmax function to obtain a class
 probability prediction. Here "distance" is computed using a user-specified distance
@@ -773,43 +779,43 @@ function.
 
 In MLJ or MLJBase, bind an instance `model` to data with
 
-  mach = machine(model, X, y)
+    mach = machine(model, X, y)
 
 Here:
 
-- `X` is any table of input features (eg, a `DataFrame`) whose columns
-are of scitype `Continuous`; check column scitypes with `schema(X)`.
+- `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype 
+    `Continuous`; check column scitypes with `schema(X)`.
 
-- `y` is the target, which can be any `AbstractVector` whose element
-scitype is `OrderedFactor` or `Multiclass`; check the scitype
-with `scitype(y)`.
+- `y` is the target, which can be any `AbstractVector` whose element scitype is 
+    `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
-- `normalize=true`: Option to normalize the between class variance for the number of
-observations in each class, one of `true` or `false`.
+- `normalize=true`: Option to normalize the between class variance for the number of 
+    observations in each class, one of `true` or `false`.
 
 - `outdim`: the ouput dimension, automatically set to `min(indim, nclasses-1)` if equal 
-to `0`. If a non-zero `outdim` is passed, then the actual output dimension used is 
-`min(rank, outdim)` where `rank` is the rank of the within-class covariance matrix.
+    to `0`. If a non-zero `outdim` is passed, then the actual output dimension used is 
+    `min(rank, outdim)` where `rank` is the rank of the within-class covariance matrix.
 
 - `dist=Distances.SqEuclidean()`: The distance metric to use when performing classification
-(to compare the distance between a new point and centroids in the transformed space); must
-be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., `Distances.CosineDist`.
+    (to compare the distance between a new point and centroids in the transformed space); 
+    must be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., 
+    `Distances.CosineDist`.
 
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-should have the same scitype as `X` above.
+    should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew`, which
-should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+    should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions
-returned above.
+    returned above.
 
 
 # Fitted parameters
@@ -819,8 +825,8 @@ The fields of `fitted_params(mach)` are:
 - `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
-`indim` and `outdim` are the input and output dimensions respectively (See Report 
-section below).
+    `indim` and `outdim` are the input and output dimensions respectively (See Report 
+    section below).
 
 # Report
 
@@ -833,18 +839,18 @@ The fields of `report(mach)` are:
 - `mean`: The mean of the untransformed training data. A vector of length `indim`.
 
 - `nclasses`: The number of classes directly observed in the training data (which can be
-less than the total number of classes in the class pool)
+    less than the total number of classes in the class pool)
 
 `class_means`: The class-specific means of the training data. A matrix of size 
-`(indim, nclasses)` with the ith column being the class-mean of the ith class in 
-`classes` (See fitted params section above).
+    `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+    `classes` (See fitted params section above).
 
 - `class_weights`: The weights (class counts) of each class. A vector of length 
-`nclasses` with the ith element being the class weight of the ith class in 
-`classes`. (See fitted params section above.)
+    `nclasses` with the ith element being the class weight of the ith class in 
+    `classes`. (See fitted params section above.)
 
-- `explained_variance_ratio`: The ratio of explained variance to total variance. Each
-dimension corresponds to an eigenvalue.
+- `explained_variance_ratio`: The ratio of explained variance to total variance. Each 
+    dimension corresponds to an eigenvalue.
 
 # Examples
 
@@ -880,44 +886,44 @@ is derived as in [`BayesianLDA`](@ref).
 
 In MLJ or MLJBase, bind an instance `model` to data with
 
-  mach = machine(model, X, y)
+    mach = machine(model, X, y)
 
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype
-`Continuous`; check column scitypes with `schema(X)`.
+    `Continuous`; check column scitypes with `schema(X)`.
 
 - `y` is the target, which can be any `AbstractVector` whose element scitype is
-`OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`.
+    `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
 - `normalize=true`: Option to normalize the between class variance for the number of
-observations in each class, one of `true` or `false`.
+    observations in each class, one of `true` or `false`.
 
 `outdim`: the ouput dimension, automatically set to `min(indim, nclasses-1)` if equal 
-to `0`. If a non-zero `outdim` is passed, then the actual output dimension used is 
-`min(rank, outdim)` where `rank` is the rank of the within-class covariance matrix.
+    to `0`. If a non-zero `outdim` is passed, then the actual output dimension used is 
+    `min(rank, outdim)` where `rank` is the rank of the within-class covariance matrix.
 
 - `priors::Union{Nothing, UnivariateFinite{<:Any, <:Any, <:Any, <:Real}, 
-Dict{<:Any, <:Real}} = nothing`: For use in prediction with Bayes rule. If `priors = nothing` 
-then `priors` are estimated from the class proportions in the training data. Otherwise it 
-requires a `Dict` or `UnivariateFinite` object specifying the classes with non-zero 
-probabilities in the training target.
+    Dict{<:Any, <:Real}} = nothing`: For use in prediction with Bayes rule. If 
+    `priors = nothing` then `priors` are estimated from the class proportions in the 
+    training data. Otherwise it requires a `Dict` or `UnivariateFinite` object specifying 
+    the classes with non-zero probabilities in the training target.
 
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-should have the same scitype as `X` above.
+    should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew`, which
-should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+    should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions
-returned above.
+    returned above.
 
 
 # Fitted parameters
@@ -927,11 +933,11 @@ The fields of `fitted_params(mach)` are:
 - `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
-`indim` and `outdim` are the input and output dimensions respectively (See Report 
-section below).
+    `indim` and `outdim` are the input and output dimensions respectively (See Report 
+    section below).
 
 - `priors`: The class priors for classification. As inferred from training target `y`, if
-not user-specified. A UnivariateFinite object with levels consistent with `levels(y)`.
+    not user-specified. A UnivariateFinite object with levels consistent with `levels(y)`.
 
 # Report
 
@@ -944,18 +950,18 @@ The fields of `report(mach)` are:
 - `mean`: The overall mean of the training data.
 
 - `nclasses`: The number of classes directly observed in the training data (which can be
-less than the total number of classes in the class pool).
+    less than the total number of classes in the class pool).
 
 `class_means`: The class-specific means of the training data. A matrix of size 
-`(indim, nclasses)` with the ith column being the class-mean of the ith class in 
-`classes` (See fitted params section above).
+    `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+    `classes` (See fitted params section above).
 
-- `class_weights`: The weights (class counts) of each class. A vector of length 
-`nclasses` with the ith element being the class weight of the ith class in 
-`classes`. (See fitted params section above.)
+- `class_weights`: The weights (class counts) of each class. A vector of length `nclasses` 
+    with the ith element being the class weight of the ith class in `classes`. (See 
+    fitted params section above.)
 
-- `explained_variance_ratio`: The ratio of explained variance to total variance. Each
-dimension corresponds to an eigenvalue.
+- `explained_variance_ratio`: The ratio of explained variance to total variance. Each 
+    dimension corresponds to an eigenvalue.
 
 # Examples
 

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -142,7 +142,7 @@ end
 
 function _matrix_transpose(::Union{LDA,BayesianLDA}, X)
     # MultivariateStats 9.0 is not supporting adjoints
-    return MMI.matrix(X, transpose=true)
+    return MMI.matrix(X)'
 end
 
 function _check_prob01(priors)

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -167,7 +167,7 @@ end
   end
   priors_ = pdf.(priors, support(priors))
   _check_prob01(priors_)
-  # Select priors for unique classes in `y` (For resampling purporses).
+  # Select priors for unique classes in `y` (For resampling purposes).
   return pdf.(priors, classes_seen)
 end
 

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -3,12 +3,12 @@
 ####
 
 @mlj_model mutable struct LDA <: MMI.Probabilistic
-  method::Symbol = :gevd::(_ in (:gevd, :whiten))
-  cov_w::CovarianceEstimator = MS.SimpleCovariance()
-  cov_b::CovarianceEstimator = MS.SimpleCovariance()
-  outdim::Int = 0::(_ ≥ 0)
-  regcoef::Float64 = 1e-6::(_ ≥ 0)
-  dist::SemiMetric = SqEuclidean()
+    method::Symbol = :gevd::(_ in (:gevd, :whiten))
+    cov_w::CovarianceEstimator = MS.SimpleCovariance()
+    cov_b::CovarianceEstimator = MS.SimpleCovariance()
+    outdim::Int = 0::(_ ≥ 0)
+    regcoef::Float64 = 1e-6::(_ ≥ 0)
+    dist::SemiMetric = SqEuclidean()
 end
 
 const ERR_LONE_TARGET_CLASS = ArgumentError(

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -12,11 +12,11 @@
 end
 
 const ERR_LONE_TARGET_CLASS = ArgumentError(
-  "The number of unique classes in "*
-  "the training target has to be greater than one, even if "*
-  "the complete pool contains more than one class. If "*
-  "`cov_b=CovarianceEstimation.SimpleCovariance()` this "*
-  "restriction on classes does not apply. "
+    "The number of unique classes in "*
+    "the training target has to be greater than one, even if "*
+    "the complete pool contains more than one class. If "*
+    "`cov_b=CovarianceEstimation.SimpleCovariance()` this "*
+    "restriction on classes does not apply. "
 )
 
 function _check_lda_data(model, X, y)

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -3,130 +3,123 @@
 ####
 
 @mlj_model mutable struct LDA <: MMI.Probabilistic
-    method::Symbol = :gevd::(_ in (:gevd, :whiten))
-    cov_w::CovarianceEstimator = MS.SimpleCovariance()
-    cov_b::CovarianceEstimator = MS.SimpleCovariance()
-    outdim::Int = 0::(_ ≥ 0)
-    regcoef::Float64 = 1e-6::(_ ≥ 0)
-    dist::SemiMetric = SqEuclidean()
-end
-
-function MMI.fit(model::LDA, ::Int, X, y)
-    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, outdim =
-        _check_lda_data(model, X, y)
-    core_res = MS.fit(
-        MS.MulticlassLDA, nc, Xm_t, Int.(yplain);
-        method=model.method,
-        outdim,
-        regcoef=model.regcoef,
-        covestimator_within=model.cov_w,
-        covestimator_between=model.cov_b
-    )
-    cache = nothing
-    report = (
-        classes=classes_seen,
-        outdim=MS.size(core_res)[2],
-        projected_class_means=MS.classmeans(core_res),
-        mean=MS.mean(core_res),
-        class_weights=MS.classweights(core_res),
-        Sw=MS.withclass_scatter(core_res),
-        Sb=MS.betweenclass_scatter(core_res),
-        nclasses=nc
-    )
-    fitresult = (core_res, classes_seen)
-    return fitresult, cache, report
+  method::Symbol = :gevd::(_ in (:gevd, :whiten))
+  cov_w::CovarianceEstimator = MS.SimpleCovariance()
+  cov_b::CovarianceEstimator = MS.SimpleCovariance()
+  outdim::Int = 0::(_ ≥ 0)
+  regcoef::Float64 = 1e-6::(_ ≥ 0)
+  dist::SemiMetric = SqEuclidean()
 end
 
 const ERR_LONE_TARGET_CLASS = ArgumentError(
-    "The number of unique classes in "*
-    "the training target has to be greater than one, even if "*
-    "the complete pool contains more than one class. If "*
-    "`cov_b=CovarianceEstimation.SimpleCovariance()` this "*
-    "restriction on classes does not apply. "
+  "The number of unique classes in "*
+  "the training target has to be greater than one, even if "*
+  "the complete pool contains more than one class. If "*
+  "`cov_b=CovarianceEstimation.SimpleCovariance()` this "*
+  "restriction on classes does not apply. "
 )
 
 function _check_lda_data(model, X, y)
-    class_list = MMI.classes(y[1]) # Class list containing entries in pool of y.
-    nclasses = length(class_list)
+  pool = MMI.classes(y[1]) # Class list containing entries in pool of y.
+  classes_seen = unique(y) # Class list of actual entries in seen in y.
+  nc = length(classes_seen) # Number of classes in pool of y.
 
-    # Class list containing entries in seen in y.
-    classes_seen = filter(in(y), class_list)
-    nc = length(classes_seen) # Number of classes in pool of y.
-    integers_seen = MMI.int(classes_seen)
-    Xm_t = _matrix_transpose(model, X) # Now p x n matrix
-    yplain = MMI.int(y) # Vector of n ints in {1,..., nclasses}.
-    p, n = size(Xm_t)
+  Xm_t = _matrix_transpose(model, X) # Now p x n matrix
+  p, n = size(Xm_t)
 
-    # Recode yplain to be in {1,..., nc}
-    nc == nclasses || _replace!(yplain, integers_seen, 1:nc)
+  # Check to make sure we have more than one class in training sample.
+  # This is to prevent Sb from being a zero matrix
+  # see issue #41
+  lone_class_unsupported = model isa Union{LDA, BayesianLDA} &&
+        model.cov_b != MS.SimpleCovariance()
+  if nc <= 1 && lone_class_unsupported
+      throw(ERR_LONE_TARGET_CLASS)
+  end
 
-    # Check to make sure we have more than one class in training sample.
-    # This is to prevent Sb from being a zero matrix
-    # see issue #41
-    lone_class_unsupported = model isa Union{LDA, BayesianLDA} &&
-          model.cov_b != MS.SimpleCovariance()
-    if nc <= 1 && lone_class_unsupported
-        throw(ERR_LONE_TARGET_CLASS)
-    end
-
-    # Check to make sure we have more samples than classes.
-    # This is to prevent Sw from being the zero matrix.
-    if n <= nc
-        throw(
-            ArgumentError(
-                "The number of training samples `n` has"*
-                " to be greater than number of unique classes `nc`."
-            )
-        )
-    end
-    # Check output dimension default is min(p, nc-1)
-    def_outdim = min(p, nc - 1)
-    # If unset (0) use the default; otherwise try to use the provided one
-    outdim = ifelse(model.outdim == 0, def_outdim, model.outdim)
-    # Check if the given one is sensible
-    if outdim > def_outdim
-        throw(
-            ArgumentError(
-                "`outdim` must not be larger than `min(p, nc-1)`"*
-                "where `p` is the number of features in `X` and"*
-                "`nc` is the number of unique classes in the target vector."
-            )
-        )
-    end
-    return Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, outdim
+  # Check to make sure we have more samples than classes.
+  # This is to prevent Sw from being the zero matrix.
+  if n <= nc
+      throw(
+          ArgumentError(
+              "The number of training samples `n` has"*
+              " to be greater than number of unique classes `nc`."
+          )
+      )
+  end
+  # Check output dimension default is min(p, nc-1)
+  def_outdim = min(p, nc - 1)
+  # If unset (0) use the default; otherwise try to use the provided one
+  outdim = ifelse(model.outdim == 0, def_outdim, model.outdim)
+  # Check if the given one is sensible
+  if outdim > def_outdim
+      throw(
+          ArgumentError(
+              "`outdim` must not be larger than `min(p, nc-1)`"*
+              "where `p` is the number of features in `X` and"*
+              "`nc` is the number of unique classes in the target vector."
+          )
+      )
+  end
+  return Xm_t, y, classes_seen, pool, p, n, nc, outdim
 end
 
-function MMI.fitted_params(::LDA, (core_res, classes_seen))
-    return (
-        projected_class_means=MS.classmeans(core_res),
-        projection_matrix=MS.projection(core_res)
-    )
+function MMI.fit(model::LDA, ::Int, X, y)
+  Xm_t, _ , classes_seen, pool, _, _, nc, outdim =
+      _check_lda_data(model, X, y)
+  core_res = MS.fit(
+      MS.MulticlassLDA, Xm_t, y;
+      method=model.method,
+      outdim,
+      regcoef=model.regcoef,
+      covestimator_within=model.cov_w,
+      covestimator_between=model.cov_b
+  )
+  cache = nothing
+  report = (
+      indim = MS.size(core_res)[1],
+      outdim=MS.size(core_res)[2],
+      mean=MS.mean(core_res),
+      nclasses=nc,
+      class_means=MS.classmeans(core_res),
+      class_weights=MS.classweights(core_res),
+      Sb=MS.betweenclass_scatter(core_res),
+      Sw=MS.withclass_scatter(core_res)
+  )
+  fitresult = (core_res, classes_seen, pool)
+  return fitresult, cache, report
 end
 
-function MMI.predict(m::LDA, (core_res, classes_seen), Xnew)
-    # projection of Xnew, XWt is nt x o  where o = number of out dims
-    # nt = number ot test samples
-    XWt = MMI.matrix(Xnew) * core_res.proj
-    # centroids in the transformed space, nc x o
-    centroids = transpose(core_res.pmeans)
+function MMI.fitted_params(::LDA, (core_res, classes_seen, _))
+  return (
+      classes = classes_seen,
+      projection_matrix=MS.projection(core_res)
+  )
+end
 
-    # compute the distances in the transformed space between pairs of rows
-    # the probability matrix Pr is `n x nc` and normalised accross rows
-    Pr = pairwise(m.dist, XWt, centroids, dims=1)
-    Pr .*= -1
-    # apply a softmax transformation
-    softmax!(Pr)
-    return MMI.UnivariateFinite(classes_seen, Pr)
+function MMI.predict(m::LDA, (core_res, classes_seen, pool), Xnew)
+  # projection of Xnew, XWt is nt x o  where o = number of out dims
+  # nt = number ot test samples
+  XWt = MMI.matrix(Xnew) * MS.projection(core_res)
+  # centroids in the transformed space, nc x o
+  centroids = transpose(core_res.pmeans)
+
+  # compute the distances in the transformed space between pairs of rows
+  # the probability matrix Pr is `n x nc` and normalised accross rows
+  Pr = pairwise(m.dist, XWt, centroids, dims=1)
+  Pr .*= -1
+  # apply a softmax transformation
+  softmax!(Pr)
+  return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
 end
 
 metadata_model(
-    LDA,
-    human_name="linear discriminant analysis model",
-    input=Table(Continuous),
-    target=AbstractVector{<:Finite},
-    weights=false,
-    output=Table(Continuous),
-    path="$(PKG).LDA"
+  LDA,
+  human_name="linear discriminant analysis model",
+  input=Table(Continuous),
+  target=AbstractVector{<:Finite},
+  weights=false,
+  output=Table(Continuous),
+  path="$(PKG).LDA"
 )
 
 
@@ -135,129 +128,153 @@ metadata_model(
 ####
 
 @mlj_model mutable struct BayesianLDA <: MMI.Probabilistic
-    method::Symbol = :gevd::(_ in (:gevd, :whiten))
-    cov_w::CovarianceEstimator=MS.SimpleCovariance()
-    cov_b::CovarianceEstimator=MS.SimpleCovariance()
-    outdim::Int=0::(_ ≥ 0)
-    regcoef::Float64=1e-6::(_ ≥ 0)
-    priors::Union{Nothing, Vector{Float64}}=nothing
-end
-
-function MMI.fit(model::BayesianLDA, ::Int, X, y)
-    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, outdim =
-        _check_lda_data(model, X, y)
-    ## If piors are specified check if they makes sense.
-    ## This was put here to through errors much earlier
-    if isa(model.priors, Vector)
-        priors = _check_lda_priors(model.priors, nc, nclasses, integers_seen)
-    end
-
-    core_res = MS.fit(
-        MS.MulticlassLDA, nc, Xm_t, Int.(yplain);
-        method=model.method,
-        outdim,
-        regcoef=model.regcoef,
-        covestimator_within=model.cov_w,
-        covestimator_between=model.cov_b
-    )
-
-    ## Estimates prior probabilities if specified by user.
-    ## Put it here to avoid recomputing as the fitting process does this already
-    if isa(model.priors, Nothing)
-        weights = MS.classweights(core_res)
-        total = core_res.stats.tweight
-        priors = weights ./ total
-    end
-    cache = nothing
-    report = (
-        classes=classes_seen,
-        outdim=MS.size(core_res)[2],
-        projected_class_means=MS.classmeans(core_res),
-        mean=MS.mean(core_res),
-        class_weights=MS.classweights(core_res),
-        Sw=MS.withclass_scatter(core_res),
-        Sb=MS.betweenclass_scatter(core_res),
-        nclasses=nc
-    )
-
-    fitresult = (core_res, classes_seen, priors, n)
-    return fitresult, cache, report
+  method::Symbol = :gevd::(_ in (:gevd, :whiten))
+  cov_w::CovarianceEstimator=MS.SimpleCovariance()
+  cov_b::CovarianceEstimator=MS.SimpleCovariance()
+  outdim::Int=0::(_ ≥ 0)
+  regcoef::Float64=1e-6::(_ ≥ 0)
+  priors::Union{
+    Nothing, 
+    UnivariateFinite{<:Any, <:Any, <:Any, <:Real},
+    Dict{<:Any, <:Real}
+  }=nothing
 end
 
 function _matrix_transpose(::Union{LDA,BayesianLDA}, X)
-    # MultivariateStats 9.0 is not supporting adjoints
-    return MMI.matrix(X, transpose=true)
+  # MultivariateStats 9.0 is not supporting adjoints
+  return MMI.matrix(X, transpose=true)
 end
 
-@inline function _check_lda_priors(priors, nc, nclasses, integers_seen)
-    if length(priors) != nclasses
-        throw(ArgumentError("Invalid size of `priors`."))
-    end
+function _check_prob01(priors)
+  # `priors` is esssentially always an instance of type `Vector{<:Real}`.
+  # The next two conditions implicitly checks that
+  # ` 0 .<= priors .<= 1` and `sum(priors) ≈ 1` are true.
+  if any(<(0), priors)
+    throw(ArgumentError("probabilities specified in `priors` must non-negative"))
+  end
 
-    # `priors` is esssentially always an instance of type `Vector{Float64}`.
-    # The next two conditions implicitly checks that
-    # ` 0 .<= priors .<= 1` and `sum(priors) ≈ 1` are true.
-    if !isapprox(sum(priors), 1)
-        throw(ArgumentError("probabilities specified in `priors` must sum to 1"))
-    end
-    if all(>=(0), priors)
-        throw(ArgumentError("probabilities specified in `priors` must non-negative"))
-    end
-    # Select priors for unique classes in `y` (For resampling purporses).
-    priors_ = nc == nclasses ? model.priors : @view model.priors[integers_seen]
-    return priors_
+  if !isapprox(sum(priors), 1)
+    throw(ArgumentError("probabilities specified in `priors` must sum to 1"))
+  end
+  return nothing
 end
 
-_get_priors(priors::SubArray) = copy(priors)
-_get_priors(priors) = priors
-
-function MMI.fitted_params(::BayesianLDA, (core_res, classes_seen, priors, n))
-   return (
-       projected_class_means=MS.classmeans(core_res),
-       projection_matrix=MS.projection(core_res),
-       priors=_get_priors(priors)
-    )
+@inline function _check_lda_priors(priors::UnivariateFinite, classes_seen, pool)
+  if MMI.classes(priors) != pool
+      throw(
+        ArgumentError("UnivariateFinite `priors` must have common pool with training target.")
+      )
+  end
+  priors_ = pdf.(priors, support(priors))
+  _check_prob01(priors_)
+  # Select priors for unique classes in `y` (For resampling purporses).
+  return pdf.(priors, classes_seen)
 end
 
-function MMI.predict(m::BayesianLDA, (core_res, classes_seen, priors, n), Xnew)
-     # projection of Xnew, XWt is nt x o  where o = number of out dims
-    # nt = number ot test samples
-    XWt = MMI.matrix(Xnew) * core_res.proj
-    # centroids in the transformed space, nc x o
-    centroids = transpose(core_res.pmeans)
+@inline function _check_lda_priors(priors::Dict{K, V}, classes_seen, pool) where {K, V}
+  if !all(in(pool), keys(priors))
+      throw(
+        ArgumentError("keys used in `priors` dictionary must be in pool of training target.")
+      )
+  end
+  _check_prob01(values(priors))
+  # Select priors for unique classes in `y` (For resampling purporses).
+  priors_ = get.(Ref(priors), classes_seen, V(0))
+  return priors_
+end
 
-    # The discriminant matrix `Pr` is of dimension `nt x nc`
-    # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σw⁻¹)(xᵢ −  µₖ) + log(priorsₖ) where (Σw = Sw/n)
-    # In the transformed space this becomes
-    # Pr[i,k] = -0.5*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(PᵀΣw⁻¹P)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
-    # But PᵀSw⁻¹P = I and PᵀΣw⁻¹P = n*I due to the nature of the projection_matrix, P
-    # Giving Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
-    # with (Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) being the SquaredEquclidean distance between
-    # pairs of rows in the transformed space
-    Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
-    Pr .*= (-n/2)
-    Pr .+= log.(transpose(priors))
+_check_lda_priors(priors::Nothing, classes_seen, pool) = nothing
 
-    # apply a softmax transformation to convert Pr to a probability matrix
-    softmax!(Pr)
-    return MMI.UnivariateFinite(classes_seen, Pr)
+function MMI.fit(model::BayesianLDA, ::Int, X, y)
+  Xm_t, _, classes_seen, pool, _, n, nc, outdim =
+      _check_lda_data(model, X, y)
+  ## If piors are specified check if they makes sense.
+  ## This was put here to through errors much earlier
+  priors_ = _check_lda_priors(model.priors, classes_seen, pool)
+
+  core_res = MS.fit(
+      MS.MulticlassLDA, Xm_t, y;
+      method=model.method,
+      outdim,
+      regcoef=model.regcoef,
+      covestimator_within=model.cov_w,
+      covestimator_between=model.cov_b
+  )
+
+  ## Estimates prior probabilities if specified by user.
+  ## Put it here to avoid recomputing as the fitting process does this already
+  if priors_ === nothing
+      weights = MS.classweights(core_res)
+      total = core_res.stats.tweight
+      priors = weights ./ total
+  else
+      priors = priors_
+  end
+
+  cache = nothing
+  report = (
+      classes=classes_seen,
+      indim = MS.size(core_res)[1],
+      outdim=MS.size(core_res)[2],
+      mean=MS.mean(core_res),
+      nclasses=nc,
+      class_means=MS.classmeans(core_res),
+      class_weights=MS.classweights(core_res),
+      Sb=MS.betweenclass_scatter(core_res),
+      Sw=MS.withclass_scatter(core_res)
+  )
+
+  fitresult = (core_res, classes_seen, pool, priors, n)
+  return fitresult, cache, report
+end
+
+function MMI.fitted_params(::BayesianLDA, (core_res, classes_seen, pool,  priors, _))
+ return (
+     classes = classes_seen,
+     projection_matrix=MS.projection(core_res),
+     priors=MMI.UnivariateFinite(classes_seen, priors, pool=pool)
+  )
+end
+
+function MMI.predict(m::BayesianLDA, (core_res, classes_seen, pool, priors, n), Xnew)
+   # projection of Xnew, XWt is nt x o  where o = number of out dims
+  # nt = number ot test samples
+  XWt = MMI.matrix(Xnew) * core_res.proj
+  # centroids in the transformed space, nc x o
+  centroids = transpose(core_res.pmeans)
+
+  # The discriminant matrix `Pr` is of dimension `nt x nc`
+  # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σw⁻¹)(xᵢ −  µₖ) + log(priorsₖ) where (Σw = Sw/n)
+  # In the transformed space this becomes
+  # Pr[i,k] = -0.5*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(PᵀΣw⁻¹P)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
+  # But PᵀSw⁻¹P = I and PᵀΣw⁻¹P = n*I due to the nature of the projection_matrix, P
+  # Giving Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
+  # with (Pᵀxᵢ −  Pᵀµₖ)ᵀ(Pᵀxᵢ −  Pᵀµₖ) being the SquaredEquclidean distance between
+  # pairs of rows in the transformed space
+  Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
+  Pr .*= (-n/2)
+  Pr .+= log.(transpose(priors))
+
+  # apply a softmax transformation to convert Pr to a probability matrix
+  softmax!(Pr)
+  return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
 end
 
 function MMI.transform(m::T, (core_res, ), X) where T<:Union{LDA, BayesianLDA}
-    # projection of X, XWt is nt x o  where o = out dims
-    proj = core_res.proj #proj is the projection_matrix
-    XWt = MMI.matrix(X) * proj
-    return MMI.table(XWt, prototype = X)
+  # projection of X, XWt is nt x o  where o = out dims
+  proj = MS.projection(core_res) #proj is the projection_matrix
+  XWt = MMI.matrix(X) * proj
+  return MMI.table(XWt, prototype = X)
 end
 
 metadata_model(
-    BayesianLDA,
-    human_name="Bayesian LDA model",
-    input=Table(Continuous),
-    target= AbstractVector{<:Finite},
-    weights=false,
-    output=Table(Continuous),
-    path="$(PKG).BayesianLDA"
+  BayesianLDA,
+  human_name="Bayesian LDA model",
+  input=Table(Continuous),
+  target= AbstractVector{<:Finite},
+  weights=false,
+  output=Table(Continuous),
+  path="$(PKG).BayesianLDA"
 )
 
 ####
@@ -265,81 +282,84 @@ metadata_model(
 ####
 
 @mlj_model mutable struct SubspaceLDA <: MMI.Probabilistic
-    normalize::Bool = true
-    outdim::Int = 0::(_ ≥ 0)
-    dist::SemiMetric = SqEuclidean()
+  normalize::Bool = true
+  outdim::Int = 0::(_ ≥ 0)
+  dist::SemiMetric = SqEuclidean()
 end
 
 function subspace_outdim(core_res, outdim)
-    # `projLDA` is a `r x min(r, nc - 1)`  where `r` is the rank of the within-class
-    # scatter matrix and `nc` is the number of classes seen in the training sample.
-    projLDA = core_res.projLDA
-    return min(size(projLDA, 2), outdim) # the same as `min(r, outdim)`
+  # `projLDA` is a `r x min(r, nc - 1)`  where `r` is the rank of the within-class
+  # scatter matrix and `nc` is the number of classes seen in the training sample.
+  projLDA = core_res.projLDA
+  return min(size(projLDA, 2), outdim) # the same as `min(r, outdim)`
 end
 
 function explained_variance(core_res)
-    # λ is a `min(r, nc -1) x 1` vector containing the eigen values sorted in descending order.
-    # where `r` is the rank of the within-class covariance matrix.
-    λ = core_res.λ
-    return λ ./ sum(λ) #proportions of variance
+  # λ is a `min(r, nc -1) x 1` vector containing the eigen values sorted in descending order.
+  # where `r` is the rank of the within-class covariance matrix.
+  λ = core_res.λ
+  return λ ./ sum(λ) #proportions of variance
 end
 
 function MMI.fit(model::SubspaceLDA, ::Int, X, y)
-    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, outdim =
-        _check_lda_data(model, X, y)
+  Xm_t, _, classes_seen, pool, _, _, nc, outdim =
+      _check_lda_data(model, X, y)
 
-    core_res = MS.fit(
-        MS.SubspaceLDA, Xm_t, Int.(yplain), nc;
-        normalize = model.normalize
-    )
+  core_res = MS.fit(
+      MS.SubspaceLDA, Xm_t, y;
+      normalize = model.normalize
+  )
 
-    explained_variance_ratio = explained_variance(core_res)
-    cache = nothing
-
-    report = (
-        explained_variance_ratio=explained_variance_ratio,
-        classes=classes_seen,
-        projected_class_means=MS.classmeans(core_res),
-        mean=MS.mean(core_res),
-        class_weights=MS.classweights(core_res),
-        nclasses=nc
-    )
-    outdim = subspace_outdim(core_res, outdim)
-    fitresult = (core_res, outdim, classes_seen)
-    return fitresult, cache, report
+  cache = nothing
+  outdim = subspace_outdim(core_res, outdim)
+  report = (
+      indim = MS.size(core_res)[1],
+      outdim = outdim,
+      mean=MS.mean(core_res),
+      nclasses=nc,
+      class_means=MS.classmeans(core_res),
+      class_weights=MS.classweights(core_res),
+      explained_variance_ratio=explained_variance(core_res),
+  )
+  
+  fitresult = (core_res, outdim, classes_seen, pool)
+  return fitresult, cache, report
 end
 
-function MMI.fitted_params(::SubspaceLDA, (core_res, _))
-    return (projected_class_means=MS.classmeans(core_res), projection_matrix=MS.projection(core_res))
+function MMI.fitted_params(::SubspaceLDA, (core_res, outdim, classes_seen, _))
+  return (
+    classes=classes_seen, 
+    projection_matrix=core_res.projw * view(core_res.projLDA, :, 1:outdim)
+  )
 end
 
-function MMI.predict(m::SubspaceLDA, (core_res, outdim, classes_seen), Xnew)
-    # projection of `Xnew`, `XWt` is `nt x o` where `o` is the number of out dims
-    # and `nt` is the number ot test samples.
-    # `proj` is the overall projection_matrix
-    proj = core_res.projw * @view(core_res.projLDA[:, 1:outdim])
-    XWt = MMI.matrix(Xnew) * proj
+function MMI.predict(m::SubspaceLDA, (core_res, outdim, classes_seen, pool), Xnew)
+  # projection of `Xnew`, `XWt` is `nt x o` where `o` is the number of out dims
+  # and `nt` is the number ot test samples.
+  # `proj` is the overall projection_matrix
+  proj = core_res.projw * @view(core_res.projLDA[:, 1:outdim])
+  XWt = MMI.matrix(Xnew) * proj
 
-    # centroids in the transformed space, nc x o
-    centroids = transpose(core_res.cmeans) * proj
+  # centroids in the transformed space, nc x o
+  centroids = transpose(core_res.cmeans) * proj
 
-    # Compute the distances in the transformed space between pairs of rows
-    # the probability matrix is `nt x nc` and normalised accross rows
-    Pr = pairwise(m.dist, XWt, centroids, dims=1)
-    Pr .*= -1
-    # apply a softmax transformation
-    softmax!(Pr)
-    return MMI.UnivariateFinite(classes_seen, Pr)
+  # Compute the distances in the transformed space between pairs of rows
+  # the probability matrix is `nt x nc` and normalised accross rows
+  Pr = pairwise(m.dist, XWt, centroids, dims=1)
+  Pr .*= -1
+  # apply a softmax transformation
+  softmax!(Pr)
+  return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
 end
 
 metadata_model(
-    SubspaceLDA,
-    human_name="subpace LDA model",
-    input=Table(Continuous),
-    target=AbstractVector{<:Finite},
-    weights=false,
-    output=Table(Continuous),
-    path="$(PKG).SubspaceLDA"
+  SubspaceLDA,
+  human_name="subpace LDA model",
+  input=Table(Continuous),
+  target=AbstractVector{<:Finite},
+  weights=false,
+  output=Table(Continuous),
+  path="$(PKG).SubspaceLDA"
 )
 
 ####
@@ -347,117 +367,127 @@ metadata_model(
 ####
 
 @mlj_model mutable struct BayesianSubspaceLDA <: MMI.Probabilistic
-    normalize::Bool=false
-    outdim::Int= 0::(_ ≥ 0)
-    priors::Union{Nothing, Vector{Float64}}=nothing
+  normalize::Bool=false
+  outdim::Int= 0::(_ ≥ 0)
+  priors::Union{
+    Nothing, 
+    UnivariateFinite{<:Any, <:Any, <:Any, <:Real},
+    Dict{<:Any, <:Real}
+  }=nothing
 end
 
 function MMI.fit(model::BayesianSubspaceLDA, ::Int, X, y)
-    Xm_t, yplain, classes_seen, p, n, nc, nclasses, integers_seen, outdim =
-        _check_lda_data(model, X, y)
-    ## If piors are specified check if they makes sense.
-    ## This was put here to through errors much earlier
-    if isa(model.priors, Vector)
-        priors = _check_lda_priors(model.priors, nc, nclasses, integers_seen)
-    end
+  Xm_t, _, classes_seen, pool, _, n, nc, outdim =
+      _check_lda_data(model, X, y)
+  ## If piors are specified check if they makes sense.
+  ## This was put here to through errors much earlier
+  priors_ = _check_lda_priors(model.priors, classes_seen, pool)
 
-    core_res = MS.fit(
-        MS.SubspaceLDA, Xm_t, Int.(yplain), nc;
-        normalize = model.normalize
-    )
+  core_res = MS.fit(
+      MS.SubspaceLDA, Xm_t, y;
+      normalize = model.normalize
+  )
 
-    explained_variance_ratio = explained_variance(core_res)
-    mult = model.normalize ? n : 1 #used in prediction
+  explained_variance_ratio = explained_variance(core_res)
+  mult = model.normalize ? n : 1 #used in prediction
 
-    ## Estimates prior probabilities if specified by user.
-    ## Put it here to avoid recomputing as the fitting process does this already
-    if isa(model.priors, Nothing)
-        weights = MS.classweights(core_res)
-        priors = weights ./ n
-    end
+  ## Estimates prior probabilities if specified by user.
+  ## Put it here to avoid recomputing as the fitting process does this already
+  if priors_ === nothing
+      weights = MS.classweights(core_res)
+      priors = weights ./ n
+  else
+      priors = priors_
+  end
 
-    cache = nothing
-    report = (
-        explained_variance_ratio=explained_variance_ratio,
-        classes=classes_seen,
-        projected_class_means=MS.classmeans(core_res),
-        mean=MS.mean(core_res),
-        class_weights=MS.classweights(core_res),
-        nclasses=nc
-    )
-    outdim = subspace_outdim(core_res, outdim)
-    fitresult = (core_res, outdim, classes_seen, priors, n, mult)
-    return fitresult, cache, report
+  cache = nothing
+  outdim = subspace_outdim(core_res, outdim)
+  report = (
+      indim = MS.size(core_res)[1],
+      outdim = outdim,
+      mean=MS.mean(core_res),
+      nclasses=nc,
+      class_means=MS.classmeans(core_res),
+      class_weights=MS.classweights(core_res),
+      explained_variance_ratio=explained_variance(core_res),
+  )
+  
+  fitresult = (core_res, outdim, classes_seen, pool, priors, n, mult)
+  return fitresult, cache, report
 end
 
 function _matrix_transpose(model::Union{SubspaceLDA, BayesianSubspaceLDA}, X)
-    return MMI.matrix(X)'
+  return MMI.matrix(X)'
 end
 
-function MMI.fitted_params(::BayesianSubspaceLDA, (core_res, _, _, priors,_))
-    return (
-        projected_class_means=MS.classmeans(core_res),
-        projection_matrix=MS.projection(core_res),
-        priors=_get_priors(priors)
-    )
+function MMI.fitted_params(
+  ::BayesianSubspaceLDA, (core_res, outdim, classes_seen, pool, priors, _, _)
+)
+  return (
+      classes = classes_seen,
+      projection_matrix=core_res.projw * view(core_res.projLDA, :, 1:outdim),
+      priors=MMI.UnivariateFinite(classes_seen, priors, pool=pool)
+  )
 end
 
 function MMI.predict(
-    m::BayesianSubspaceLDA,
-    (core_res, outdim, classes_seen, priors, n, mult),
-    Xnew
+  m::BayesianSubspaceLDA,
+  (core_res, outdim, classes_seen, pool, priors, n, mult),
+  Xnew
 )
-    # projection of `Xnew`, `XWt` is `nt x o` where `o` is the number of out dims
-    # and `nt` is the number ot test samples.
-    # `proj` is the overall projection_matrix
-    proj = core_res.projw * @view(core_res.projLDA[:, 1:outdim])
-    XWt = MMI.matrix(Xnew) * proj
+  # projection of `Xnew`, `XWt` is `nt x o` where `o` is the number of out dims
+  # and `nt` is the number ot test samples.
+  # `proj` is the overall projection_matrix
+  proj = core_res.projw * @view(core_res.projLDA[:, 1:outdim])
+  XWt = MMI.matrix(Xnew) * proj
 
-    # centroids in the transformed space, `nc x o`
-    centroids = transpose(core_res.cmeans) * proj
-    nc = length(classes_seen)
+  # centroids in the transformed space, `nc x o`
+  centroids = transpose(core_res.cmeans) * proj
+  nc = length(classes_seen)
 
-    # compute the distances in the transformed space between pairs of rows
-    # The discriminant matrix `Pr` is of dimension `nt x nc`
-    # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σ⁻¹)(xᵢ −  µₖ) + log(priorsₖ)
-    # where `Σ = Sw/(n-nc)` is the within-class covariance matrix which maybe singular,
-    # Using `P` to project to the subspace spanned by the within-class covariance matrix
-    # The discriminant matrix `Pr` becomes
-    # Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Σw⁻¹)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
-    # where `Σw = PᵀSwP/(n-nc)` is now non-singular,
-    # Applying the LDA projection, `L` in the subspace spanned by the within-class
-    # covariance matrix, this becomes
-    # Pr[i,k] = -0.5*(LᵀPᵀxᵢ −  LᵀPᵀµₖ)ᵀ(LᵀΣw⁻¹Lᵀ)(Lᵀxᵢ −  ᵀlµₖ) + log(priorsₖ)
-    # But LᵀΣw⁻¹L = ((n-nc)/mult)*I and `M = PL`
-    # Giving Pr[i,k] = -0.5*n*(Mᵀxᵢ −  Mᵀµₖ)ᵀ(Mᵀxᵢ −  Mᵀµₖ) + log(priorsₖ)
-    # where (Mᵀxᵢ −  Mᵀµₖ)ᵀ(Mᵀxᵢ −  Mᵀµₖ) is the SquaredEquclidean distance in the
-    # space spanned by the overall projection `PL`
-    Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
-    Pr .*= (-(n-nc)/2mult)
-    Pr .+= log.(transpose(priors))
+  # compute the distances in the transformed space between pairs of rows
+  # The discriminant matrix `Pr` is of dimension `nt x nc`
+  # Pr[i,k] = -0.5*(xᵢ −  µₖ)ᵀ(Σ⁻¹)(xᵢ −  µₖ) + log(priorsₖ)
+  # where `Σ = Sw/(n-nc)` is the within-class covariance matrix which maybe singular,
+  # Using `P` to project to the subspace spanned by the within-class covariance matrix
+  # The discriminant matrix `Pr` becomes
+  # Pr[i,k] = -0.5*n*(Pᵀxᵢ −  Pᵀµₖ)ᵀ(Σw⁻¹)(Pᵀxᵢ −  Pᵀµₖ) + log(priorsₖ)
+  # where `Σw = PᵀSwP/(n-nc)` is now non-singular,
+  # Applying the LDA projection, `L` in the subspace spanned by the within-class
+  # covariance matrix, this becomes
+  # Pr[i,k] = -0.5*(LᵀPᵀxᵢ −  LᵀPᵀµₖ)ᵀ(LᵀΣw⁻¹Lᵀ)(Lᵀxᵢ −  ᵀlµₖ) + log(priorsₖ)
+  # But LᵀΣw⁻¹L = ((n-nc)/mult)*I and `M = PL`
+  # Giving Pr[i,k] = -0.5*n*(Mᵀxᵢ −  Mᵀµₖ)ᵀ(Mᵀxᵢ −  Mᵀµₖ) + log(priorsₖ)
+  # where (Mᵀxᵢ −  Mᵀµₖ)ᵀ(Mᵀxᵢ −  Mᵀµₖ) is the SquaredEquclidean distance in the
+  # space spanned by the overall projection `PL`
+  Pr = pairwise(SqEuclidean(), XWt, centroids, dims=1)
+  Pr .*= (-(n-nc)/2mult)
+  Pr .+= log.(transpose(priors))
 
-    # apply a softmax transformation to convert Pr to a probability matrix
-    softmax!(Pr)
-    return MMI.UnivariateFinite(classes_seen, Pr)
+  # apply a softmax transformation to convert Pr to a probability matrix
+  softmax!(Pr)
+  return MMI.UnivariateFinite(classes_seen, Pr, pool=pool)
 end
 
-function MMI.transform(m::T, (core_res, outdim, _), X) where T<:Union{SubspaceLDA, BayesianSubspaceLDA}
-    # projection of `X`, `XWt` is `nt x o`  where `o` is the out dims and
-    # `nt` is the number of test cases
-    proj = core_res.projw * view(core_res.projLDA, :, 1:outdim)
-    # `proj` is overall the projection_matrix
-    XWt = MMI.matrix(X) * proj
-    return MMI.table(XWt, prototype = X)
+function MMI.transform(
+  m::T, (core_res, outdim, _), X
+) where T<:Union{SubspaceLDA, BayesianSubspaceLDA}
+  # projection of `X`, `XWt` is `nt x o`  where `o` is the out dims and
+  # `nt` is the number of test cases
+  proj = core_res.projw * view(core_res.projLDA, :, 1:outdim)
+  # `proj` is overall the projection_matrix
+  XWt = MMI.matrix(X) * proj
+  return MMI.table(XWt, prototype = X)
 end
 
 metadata_model(
-    BayesianSubspaceLDA,
-    human_name="Bayesian subspace LDA model",
-    input=Table(Continuous),
-    target=AbstractVector{<:Finite},
-    weights=false,
-    output=Table(Continuous),
-    path="$(PKG).BayesianSubspaceLDA"
+  BayesianSubspaceLDA,
+  human_name="Bayesian subspace LDA model",
+  input=Table(Continuous),
+  target=AbstractVector{<:Finite},
+  weights=false,
+  output=Table(Continuous),
+  path="$(PKG).BayesianSubspaceLDA"
 )
 
 
@@ -485,7 +515,7 @@ one, is passed to a softmax function to obtain a class probability prediction. H
 
 In MLJ or MLJBase, bind an instance `model` to data with
 
-    mach = machine(model, X, y)
+  mach = machine(model, X, y)
 
 Here:
 
@@ -493,8 +523,8 @@ Here:
 are of scitype `Continuous`; check column scitypes with `schema(X)`.
 
 - `y` is the target, which can be any `AbstractVector` whose element
-  scitype is `OrderedFactor` or `Multiclass`; check the scitype
-  with `scitype(y)`
+scitype is `OrderedFactor` or `Multiclass`; check the scitype
+with `scitype(y)`
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -503,68 +533,71 @@ Train the machine using `fit!(mach, rows=...)`.
 - `method::Symbol=:gevd`: The solver, one of `:gevd` or `:whiten` methods.
 
 - `cov_w::StatsBase.SimpleCovariance()`: An estimator for the within-class
-  covariance (used in computing the within-class scatter matrix, `Sw`). Any robust estimator
-  from `CovarianceEstimation.jl` can be used.
+covariance (used in computing the within-class scatter matrix, `Sw`). Any robust estimator
+from `CovarianceEstimation.jl` can be used.
 
 - `cov_b::StatsBase.SimpleCovariance()`: The same as `cov_w` but for the
-  between-class covariance (used in computing the between-class scatter matrix, `Sb`).
+between-class covariance (used in computing the between-class scatter matrix, `Sb`).
 
 - `outdim::Int=0`: The output dimension, i.e dimension of the transformed space,
-  automatically set if equal to 0.
+automatically set to `min(indim, nclasses-1)` if equal to 0.
 
 - `regcoef::Float64=1e-6`: The regularization coefficient. A positive value
-  `regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
-  diagonal of `Sw` to improve numerical stability. This can be useful if using the standard
-  covariance estimator.
+`regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
+diagonal of `Sw` to improve numerical stability. This can be useful if using the standard
+covariance estimator.
 
 - `dist=Distances.SqEuclidean()`: The distance metric to use when performing classification
-  (to compare the distance between a new point and centroids in the transformed space); must
-  be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., `Distances.CosineDist`.
+(to compare the distance between a new point and centroids in the transformed space); must
+be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., `Distances.CosineDist`.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-  should have the same scitype as `X` above.
+should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew` having the
-  same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+same scitype as `X` above. Predictions are probabilistic but uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions returned
-  above.
+above.
 
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
-- `projected_class_means`: The matrix comprised of class-specific means as columns, of size
-  `(indim, nclasses)`, where `indim` is the number of input features (columns) and
-  `nclasses` the number of target classes.
+- `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
- `indim` and `outdim` are the input and output dimensions respectively.
+`indim` and `outdim` are the input and output dimensions respectively (See Report 
+section below).
 
 # Report
 
 The fields of `report(mach)` are:
 
-- `classes`: The classes seen during model fitting.
+- `indim`: The dimension of the input space i.e the number of features of training matrix.
 
-- `outdim`: The dimensions the model is projected to.
+- `outdim`: The dimension of the transformed space the model is projected to.
 
-- `projected_class_means`: The matrix comprised of class-specific means as
-  columns (see above).
+- `mean`: The mean of the untransformed training data. A vector of length `indim`.
 
-- `mean`: The mean of the untransformed training data, of length `indim`.
+- `nclasses`: The number of classes directly observed in the training data (which can be
+less than the total number of classes in the class pool).
 
-- `class_weights`: The weights of each class.
+- `class_means`: The class-specific means of the training data. A matrix of size 
+`(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+`classes` (See fitted params section above).
+
+- `class_weights`: The weights (class counts) of each class. A vector of length 
+`nclasses` with the ith element being the class weight of the ith class in 
+`classes`. (See fitted params section above.)
 
 - `Sb`: The between class scatter matrix.
 
 - `Sw`: The within class scatter matrix.
 
-- `nclasses`: The number of classes directly observed in the training data (which can be
-  less than the total number of classes in the class pool)
 
 # Examples
 
@@ -608,15 +641,15 @@ Investigation](https://doi.org/10.1007/s10115-006-0013-y).
 
 In MLJ or MLJBase, bind an instance `model` to data with
 
-    mach = machine(model, X, y)
+  mach = machine(model, X, y)
 
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype
-  `Continuous`; check column scitypes with `schema(X)`.
+`Continuous`; check column scitypes with `schema(X)`.
 
 - `y` is the target, which can be any `AbstractVector` whose element scitype is
-  `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`
+`OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -625,73 +658,75 @@ Train the machine using `fit!(mach, rows=...)`.
 - `method::Symbol=:gevd`: choice of solver, one of `:gevd` or `:whiten` methods.
 
 - `cov_w::StatsBase.SimpleCovariance()`: An estimator for the within-class
-  covariance (used in computing the within-class scatter matrix, `Sw`). Any robust estimator
-  from `CovarianceEstimation.jl` can be used.
+covariance (used in computing the within-class scatter matrix, `Sw`). Any robust estimator
+from `CovarianceEstimation.jl` can be used.
 
 - `cov_b::StatsBase.SimpleCovariance()`: The same as `cov_w` but for the
-  between-class covariance (used in computing the between-class scatter matrix, `Sb`).
+between-class covariance (used in computing the between-class scatter matrix, `Sb`).
 
 - `outdim::Int=0`: The output dimension, i.e., dimension of the transformed space,
-  automatically set if equal to 0.
+automatically set to `min(indim, nclasses-1)` if equal to 0.
 
 - `regcoef::Float64=1e-6`: The regularization coefficient. A positive value
-  `regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
-  diagonal of `Sw` to improve numerical stability. This can be useful if using the standard
-  covariance estimator.
+`regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
+diagonal of `Sw` to improve numerical stability. This can be useful if using the standard
+covariance estimator.
 
-- `priors::Union{Nothing, Vector{Float64}}=nothing`: For use in prediction with Bayes'
-  rule. If `priors = nothing` then `priors` are estimated from the class proportions in the
-  training data. Otherwise it requires a `Vector` containing class probabilities with
-  probabilities specified using the order given by `levels(y)`, where `y` is the training
-  target.
+- `priors::Union{Nothing, UnivariateFinite{<:Any, <:Any, <:Any, <:Real}, 
+Dict{<:Any, <:Real}} = nothing`: For use in prediction with Bayes rule. If `priors = nothing` 
+then `priors` are estimated from the class proportions in the training data. Otherwise it 
+requires a `Dict` or `UnivariateFinite` object specifying the classes with non-zero 
+probabilities in the training target.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-  should have the same scitype as `X` above.
+should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew`, which
-  should have the same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+should have the same scitype as `X` above. Predictions are probabilistic but uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions returned
-  above.
+above.
 
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
-- `projected_class_means`: The matrix comprised of class-specific means as columns, of size
-  `(indim, nclasses)`, where `indim` is the number of input features (columns) and
-  `nclasses` the number of target classes.
+- `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
- `indim` and `outdim` are the input and output dimensions respectively.
+`indim` and `outdim` are the input and output dimensions respectively (See Report 
+section below).
 
 - `priors`: The class priors for classification. As inferred from training target `y`, if
-  not user-specified. A vector with order consistent with `levels(y)`.
+not user-specified. A UnivariateFinite object with levels consistent with `levels(y)`.
 
 # Report
 
 The fields of `report(mach)` are:
 
-- `classes`: The classes seen during model fitting.
+- `indim`: The dimension of the input space i.e the number of features of training matrix.
 
-- `outdim`: The dimensions the model is projected to.
+- `outdim`: The dimension of the transformed space the model is projected to.
 
-- `projected_class_means`: The matrix comprised of class-specific means as columns (see
-  above).
+- `mean`: The mean of the untransformed training data. A vector of length `indim`.
 
-- `mean`: The mean of the untransformed training data, of length `indim`.
+- `nclasses`: The number of classes directly observed in the training data (which can be
+less than the total number of classes in the class pool).
 
-- `class_weights`: The weights of each class.
+- `class_means`: The class-specific means of the training data. A matrix of size 
+`(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+`classes` (See fitted params section above).
+
+- `class_weights`: The weights (class counts) of each class. A vector of length 
+`nclasses` with the ith element being the class weight of the ith class in 
+`classes`. (See fitted params section above.)
 
 - `Sb`: The between class scatter matrix.
 
 - `Sw`: The within class scatter matrix.
-
-- `nclasses`: The number of classes directly observed in the training data (which can be
-  less than the total number of classes in the class pool)
 
 # Examples
 
@@ -738,7 +773,7 @@ function.
 
 In MLJ or MLJBase, bind an instance `model` to data with
 
-    mach = machine(model, X, y)
+  mach = machine(model, X, y)
 
 Here:
 
@@ -746,66 +781,70 @@ Here:
 are of scitype `Continuous`; check column scitypes with `schema(X)`.
 
 - `y` is the target, which can be any `AbstractVector` whose element
-  scitype is `OrderedFactor` or `Multiclass`; check the scitype
-  with `scitype(y)`.
+scitype is `OrderedFactor` or `Multiclass`; check the scitype
+with `scitype(y)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
 - `normalize=true`: Option to normalize the between class variance for the number of
-  observations in each class, one of `true` or `false`.
+observations in each class, one of `true` or `false`.
 
-- `outdim`: the ouput dimension, automatically set if equal to `0`. If a non-zero `outdim`
-  is passed, then the actual output dimension used is `min(rank, outdim)` where `rank` is
-  the rank of the within-class covariance matrix.
+- `outdim`: the ouput dimension, automatically set to `min(indim, nclasses-1)` if equal 
+to `0`. If a non-zero `outdim` is passed, then the actual output dimension used is 
+`min(rank, outdim)` where `rank` is the rank of the within-class covariance matrix.
 
 - `dist=Distances.SqEuclidean()`: The distance metric to use when performing classification
-  (to compare the distance between a new point and centroids in the transformed space); must
-  be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., `Distances.CosineDist`.
+(to compare the distance between a new point and centroids in the transformed space); must
+be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., `Distances.CosineDist`.
 
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-  should have the same scitype as `X` above.
+should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew`, which
-  should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions
-  returned above.
+returned above.
 
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
-- `projected_class_means`: The matrix comprised of class-specific means as columns, of size
-  `(indim, nclasses)`, where `indim` is the number of input features (columns) and
-  `nclasses` the number of target classes.
+- `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
-  `indim` and `outdim` are the input and output dimensions respectively.
+`indim` and `outdim` are the input and output dimensions respectively (See Report 
+section below).
 
 # Report
 
 The fields of `report(mach)` are:
 
-- `explained_variance_ratio`: The ratio of explained variance to total variance. Each
-  dimension corresponds to an eigenvalue.
+- `indim`: The dimension of the input space i.e the number of features of training matrix.
 
-- `classes`: The classes seen during model fitting.
+- `outdim`: The dimension of the transformed space the model is projected to.
 
-- `projected_class_means`: The matrix comprised of class-specific means as columns (see
-  above).
-
-- `mean`: The mean of the untransformed training data, of length `indim`.
-
-- `class_weights`: The weights of each class.
+- `mean`: The mean of the untransformed training data. A vector of length `indim`.
 
 - `nclasses`: The number of classes directly observed in the training data (which can be
-  less than the total number of classes in the class pool)
+less than the total number of classes in the class pool)
+
+`class_means`: The class-specific means of the training data. A matrix of size 
+`(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+`classes` (See fitted params section above).
+
+- `class_weights`: The weights (class counts) of each class. A vector of length 
+`nclasses` with the ith element being the class weight of the ith class in 
+`classes`. (See fitted params section above.)
+
+- `explained_variance_ratio`: The ratio of explained variance to total variance. Each
+dimension corresponds to an eigenvalue.
 
 # Examples
 
@@ -841,78 +880,82 @@ is derived as in [`BayesianLDA`](@ref).
 
 In MLJ or MLJBase, bind an instance `model` to data with
 
-    mach = machine(model, X, y)
+  mach = machine(model, X, y)
 
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype
-  `Continuous`; check column scitypes with `schema(X)`.
+`Continuous`; check column scitypes with `schema(X)`.
 
 - `y` is the target, which can be any `AbstractVector` whose element scitype is
-  `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`.
+`OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
 - `normalize=true`: Option to normalize the between class variance for the number of
-  observations in each class, one of `true` or `false`.
+observations in each class, one of `true` or `false`.
 
-- `outdim`: the ouput dimension, automatically set if equal to `0`. If a non-zero `outdim`
-  is passed, then the actual output dimension used is `min(rank, outdim)` where `rank` is
-  the rank of the within-class covariance matrix.
+`outdim`: the ouput dimension, automatically set to `min(indim, nclasses-1)` if equal 
+to `0`. If a non-zero `outdim` is passed, then the actual output dimension used is 
+`min(rank, outdim)` where `rank` is the rank of the within-class covariance matrix.
 
-- `priors::Union{Nothing, Vector{Float64}}=nothing`: For use in prediction with Bayes'
-  rule. If `priors = nothing` then `priors` are estimated from the class proportions
-  in the training data. Otherwise it requires a `Vector` containing class
-  probabilities with probabilities specified using the order given by `levels(y)`
-  where `y` is the training target.
+- `priors::Union{Nothing, UnivariateFinite{<:Any, <:Any, <:Any, <:Real}, 
+Dict{<:Any, <:Real}} = nothing`: For use in prediction with Bayes rule. If `priors = nothing` 
+then `priors` are estimated from the class proportions in the training data. Otherwise it 
+requires a `Dict` or `UnivariateFinite` object specifying the classes with non-zero 
+probabilities in the training target.
 
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-  should have the same scitype as `X` above.
+should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew`, which
-  should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions
-  returned above.
+returned above.
 
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
-- `projected_class_means`: The matrix comprised of class-specific means as columns,
-  of size `(indim, nclasses)`, where `indim` is the number of input features (columns) and
-  `nclasses` the number of target classes.
+- `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
- `indim` and `outdim` are the input and output dimensions respectively.
+`indim` and `outdim` are the input and output dimensions respectively (See Report 
+section below).
 
-- `priors`: The class priors for classification. As inferred from training target `y`,
-  if not user-specified. A vector with order consistent with `levels(y)`.
+- `priors`: The class priors for classification. As inferred from training target `y`, if
+not user-specified. A UnivariateFinite object with levels consistent with `levels(y)`.
 
 # Report
 
 The fields of `report(mach)` are:
 
-- `explained_variance_ratio`: The ratio of explained variance to total variance. Each
-  dimension corresponds to an eigenvalue.
+- `indim`: The dimension of the input space i.e the number of features of training matrix.
 
-- `classes`: The classes seen during model fitting.
+- `outdim`: The dimension of the transformed space the model is projected to.
 
-- `projected_class_means`: The matrix comprised of class-specific means as columns (see
-  above).
-
-- `mean`: The mean of the untransformed training data, of length `indim`.
-
-- `class_weights`: The weights of each class.
+- `mean`: The overall mean of the training data.
 
 - `nclasses`: The number of classes directly observed in the training data (which can be
-  less than the total number of classes in the class pool)
+less than the total number of classes in the class pool).
+
+`class_means`: The class-specific means of the training data. A matrix of size 
+`(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+`classes` (See fitted params section above).
+
+- `class_weights`: The weights (class counts) of each class. A vector of length 
+`nclasses` with the ith element being the class weight of the ith class in 
+`classes`. (See fitted params section above.)
+
+- `explained_variance_ratio`: The ratio of explained variance to total variance. Each
+dimension corresponds to an eigenvalue.
 
 # Examples
 

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -582,7 +582,7 @@ The fields of `fitted_params(mach)` are:
 
 The fields of `report(mach)` are:
 
-- `indim`: The dimension of the input space i.e the number of features of training matrix.
+- `indim`: The dimension of the input space i.e the number of training features.
 
 - `outdim`: The dimension of the transformed space the model is projected to.
 

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -525,10 +525,10 @@ In MLJ or MLJBase, bind an instance `model` to data with
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype 
-    `Continuous`; check column scitypes with `schema(X)`.
+  `Continuous`; check column scitypes with `schema(X)`.
 
 - `y` is the target, which can be any `AbstractVector` whose element scitype is 
-    `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`
+  `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -537,35 +537,35 @@ Train the machine using `fit!(mach, rows=...)`.
 - `method::Symbol=:gevd`: The solver, one of `:gevd` or `:whiten` methods.
 
 - `cov_w::StatsBase.SimpleCovariance()`: An estimator for the within-class
-    covariance (used in computing the within-class scatter matrix, `Sw`). Any robust 
-    estimator from `CovarianceEstimation.jl` can be used.
+  covariance (used in computing the within-class scatter matrix, `Sw`). Any robust 
+  estimator from `CovarianceEstimation.jl` can be used.
 
 - `cov_b::StatsBase.SimpleCovariance()`: The same as `cov_w` but for the
-    between-class covariance (used in computing the between-class scatter matrix, `Sb`).
+  between-class covariance (used in computing the between-class scatter matrix, `Sb`).
 
 - `outdim::Int=0`: The output dimension, i.e dimension of the transformed space,
-    automatically set to `min(indim, nclasses-1)` if equal to 0.
+  automatically set to `min(indim, nclasses-1)` if equal to 0.
 
 - `regcoef::Float64=1e-6`: The regularization coefficient. A positive value
-    `regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
-    diagonal of `Sw` to improve numerical stability. This can be useful if using the 
-    standard covariance estimator.
+  `regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
+  diagonal of `Sw` to improve numerical stability. This can be useful if using the 
+  standard covariance estimator.
 
 - `dist=Distances.SqEuclidean()`: The distance metric to use when performing classification
-    (to compare the distance between a new point and centroids in the transformed space); 
-    must be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., 
-    `Distances.CosineDist`.
+  (to compare the distance between a new point and centroids in the transformed space); 
+  must be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., 
+  `Distances.CosineDist`.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-    should have the same scitype as `X` above.
+  should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew` having the
-    same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+  same scitype as `X` above. Predictions are probabilistic but uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions returned
-    above.
+  above.
 
 
 # Fitted parameters
@@ -575,8 +575,8 @@ The fields of `fitted_params(mach)` are:
 - `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
-    `indim` and `outdim` are the input and output dimensions respectively (See Report 
-    section below).
+  `indim` and `outdim` are the input and output dimensions respectively (See Report 
+  section below).
 
 # Report
 
@@ -589,15 +589,15 @@ The fields of `report(mach)` are:
 - `mean`: The mean of the untransformed training data. A vector of length `indim`.
 
 - `nclasses`: The number of classes directly observed in the training data (which can be
-    less than the total number of classes in the class pool).
+  less than the total number of classes in the class pool).
 
 - `class_means`: The class-specific means of the training data. A matrix of size 
-    `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
-    `classes` (See fitted params section above).
+  `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+  `classes` (See fitted params section above).
 
 - `class_weights`: The weights (class counts) of each class. A vector of length 
-    `nclasses` with the ith element being the class weight of the ith class in 
-    `classes`. (See fitted params section above.)
+  `nclasses` with the ith element being the class weight of the ith class in 
+  `classes`. (See fitted params section above.)
 
 - `Sb`: The between class scatter matrix.
 
@@ -651,10 +651,10 @@ In MLJ or MLJBase, bind an instance `model` to data with
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype
-    `Continuous`; check column scitypes with `schema(X)`.
+  `Continuous`; check column scitypes with `schema(X)`.
 
 - `y` is the target, which can be any `AbstractVector` whose element scitype is
-    `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`
+  `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -663,37 +663,37 @@ Train the machine using `fit!(mach, rows=...)`.
 - `method::Symbol=:gevd`: choice of solver, one of `:gevd` or `:whiten` methods.
 
 - `cov_w::StatsBase.SimpleCovariance()`: An estimator for the within-class
-    covariance (used in computing the within-class scatter matrix, `Sw`). Any robust 
-    estimator from `CovarianceEstimation.jl` can be used.
+  covariance (used in computing the within-class scatter matrix, `Sw`). Any robust 
+  estimator from `CovarianceEstimation.jl` can be used.
 
 - `cov_b::StatsBase.SimpleCovariance()`: The same as `cov_w` but for the
-    between-class covariance (used in computing the between-class scatter matrix, `Sb`).
+  between-class covariance (used in computing the between-class scatter matrix, `Sb`).
 
 - `outdim::Int=0`: The output dimension, i.e., dimension of the transformed space,
-    automatically set to `min(indim, nclasses-1)` if equal to 0.
+  automatically set to `min(indim, nclasses-1)` if equal to 0.
 
 - `regcoef::Float64=1e-6`: The regularization coefficient. A positive value
-    `regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
-    diagonal of `Sw` to improve numerical stability. This can be useful if using the 
-    standard covariance estimator.
+  `regcoef*eigmax(Sw)` where `Sw` is the within-class scatter matrix, is added to the
+  diagonal of `Sw` to improve numerical stability. This can be useful if using the 
+  standard covariance estimator.
 
 - `priors::Union{Nothing, UnivariateFinite{<:Any, <:Any, <:Any, <:Real}, 
-    Dict{<:Any, <:Real}} = nothing`: For use in prediction with Bayes rule. If 
-    `priors = nothing` then `priors` are estimated from the class proportions in the 
-    training data. Otherwise it requires a `Dict` or `UnivariateFinite` object specifying 
-    the classes with non-zero probabilities in the training target.
+  Dict{<:Any, <:Real}} = nothing`: For use in prediction with Bayes rule. If 
+  `priors = nothing` then `priors` are estimated from the class proportions in the 
+  training data. Otherwise it requires a `Dict` or `UnivariateFinite` object specifying 
+  the classes with non-zero probabilities in the training target.
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-    should have the same scitype as `X` above.
+  should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew`, which
-    should have the same scitype as `X` above. Predictions are probabilistic but 
-    uncalibrated.
+  should have the same scitype as `X` above. Predictions are probabilistic but 
+  uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions returned
-    above.
+  above.
 
 
 # Fitted parameters
@@ -703,11 +703,11 @@ The fields of `fitted_params(mach)` are:
 - `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
-    `indim` and `outdim` are the input and output dimensions respectively (See Report 
-    section below).
+  `indim` and `outdim` are the input and output dimensions respectively (See Report 
+  section below).
 
 - `priors`: The class priors for classification. As inferred from training target `y`, if
-    not user-specified. A UnivariateFinite object with levels consistent with `levels(y)`.
+  not user-specified. A `UnivariateFinite` object with levels consistent with `levels(y)`.
 
 # Report
 
@@ -720,15 +720,15 @@ The fields of `report(mach)` are:
 - `mean`: The mean of the untransformed training data. A vector of length `indim`.
 
 - `nclasses`: The number of classes directly observed in the training data (which can be
-    less than the total number of classes in the class pool).
+  less than the total number of classes in the class pool).
 
 - `class_means`: The class-specific means of the training data. A matrix of size 
-    `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
-    `classes` (See fitted params section above).
+  `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+  `classes` (See fitted params section above).
 
 - `class_weights`: The weights (class counts) of each class. A vector of length 
-    `nclasses` with the ith element being the class weight of the ith class in 
-    `classes`. (See fitted params section above.)
+  `nclasses` with the ith element being the class weight of the ith class in 
+  `classes`. (See fitted params section above.)
 
 - `Sb`: The between class scatter matrix.
 
@@ -784,38 +784,38 @@ In MLJ or MLJBase, bind an instance `model` to data with
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype 
-    `Continuous`; check column scitypes with `schema(X)`.
+  `Continuous`; check column scitypes with `schema(X)`.
 
 - `y` is the target, which can be any `AbstractVector` whose element scitype is 
-    `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`.
+  `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
 - `normalize=true`: Option to normalize the between class variance for the number of 
-    observations in each class, one of `true` or `false`.
+  observations in each class, one of `true` or `false`.
 
 - `outdim`: the ouput dimension, automatically set to `min(indim, nclasses-1)` if equal 
-    to `0`. If a non-zero `outdim` is passed, then the actual output dimension used is 
-    `min(rank, outdim)` where `rank` is the rank of the within-class covariance matrix.
+  to `0`. If a non-zero `outdim` is passed, then the actual output dimension used is 
+  `min(rank, outdim)` where `rank` is the rank of the within-class covariance matrix.
 
 - `dist=Distances.SqEuclidean()`: The distance metric to use when performing classification
-    (to compare the distance between a new point and centroids in the transformed space); 
-    must be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., 
-    `Distances.CosineDist`.
+  (to compare the distance between a new point and centroids in the transformed space); 
+  must be a subtype of `Distances.SemiMetric` from Distances.jl, e.g., 
+  `Distances.CosineDist`.
 
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-    should have the same scitype as `X` above.
+  should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew`, which
-    should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+  should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions
-    returned above.
+  returned above.
 
 
 # Fitted parameters
@@ -825,8 +825,8 @@ The fields of `fitted_params(mach)` are:
 - `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
-    `indim` and `outdim` are the input and output dimensions respectively (See Report 
-    section below).
+  `indim` and `outdim` are the input and output dimensions respectively (See Report 
+  section below).
 
 # Report
 
@@ -839,18 +839,18 @@ The fields of `report(mach)` are:
 - `mean`: The mean of the untransformed training data. A vector of length `indim`.
 
 - `nclasses`: The number of classes directly observed in the training data (which can be
-    less than the total number of classes in the class pool)
+  less than the total number of classes in the class pool)
 
 `class_means`: The class-specific means of the training data. A matrix of size 
-    `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
-    `classes` (See fitted params section above).
+  `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+  `classes` (See fitted params section above).
 
 - `class_weights`: The weights (class counts) of each class. A vector of length 
-    `nclasses` with the ith element being the class weight of the ith class in 
-    `classes`. (See fitted params section above.)
+  `nclasses` with the ith element being the class weight of the ith class in 
+  `classes`. (See fitted params section above.)
 
 - `explained_variance_ratio`: The ratio of explained variance to total variance. Each 
-    dimension corresponds to an eigenvalue.
+  dimension corresponds to an eigenvalue.
 
 # Examples
 
@@ -891,39 +891,39 @@ In MLJ or MLJBase, bind an instance `model` to data with
 Here:
 
 - `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype
-    `Continuous`; check column scitypes with `schema(X)`.
+  `Continuous`; check column scitypes with `schema(X)`.
 
 - `y` is the target, which can be any `AbstractVector` whose element scitype is
-    `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`.
+  `OrderedFactor` or `Multiclass`; check the scitype with `scitype(y)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
 - `normalize=true`: Option to normalize the between class variance for the number of
-    observations in each class, one of `true` or `false`.
+  observations in each class, one of `true` or `false`.
 
 `outdim`: the ouput dimension, automatically set to `min(indim, nclasses-1)` if equal 
-    to `0`. If a non-zero `outdim` is passed, then the actual output dimension used is 
-    `min(rank, outdim)` where `rank` is the rank of the within-class covariance matrix.
+  to `0`. If a non-zero `outdim` is passed, then the actual output dimension used is 
+  `min(rank, outdim)` where `rank` is the rank of the within-class covariance matrix.
 
 - `priors::Union{Nothing, UnivariateFinite{<:Any, <:Any, <:Any, <:Real}, 
-    Dict{<:Any, <:Real}} = nothing`: For use in prediction with Bayes rule. If 
-    `priors = nothing` then `priors` are estimated from the class proportions in the 
-    training data. Otherwise it requires a `Dict` or `UnivariateFinite` object specifying 
-    the classes with non-zero probabilities in the training target.
+  Dict{<:Any, <:Real}} = nothing`: For use in prediction with Bayes rule. If 
+  `priors = nothing` then `priors` are estimated from the class proportions in the 
+  training data. Otherwise it requires a `Dict` or `UnivariateFinite` object specifying 
+  the classes with non-zero probabilities in the training target.
 
 
 # Operations
 
 - `transform(mach, Xnew)`: Return a lower dimensional projection of the input `Xnew`, which
-    should have the same scitype as `X` above.
+  should have the same scitype as `X` above.
 
 - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew`, which
-    should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
+  should have same scitype as `X` above. Predictions are probabilistic but uncalibrated.
 
 - `predict_mode(mach, Xnew)`: Return the modes of the probabilistic predictions
-    returned above.
+  returned above.
 
 
 # Fitted parameters
@@ -933,11 +933,11 @@ The fields of `fitted_params(mach)` are:
 - `classes`: The classes seen during model fitting.
 
 - `projection_matrix`: The learned projection matrix, of size `(indim, outdim)`, where
-    `indim` and `outdim` are the input and output dimensions respectively (See Report 
-    section below).
+  `indim` and `outdim` are the input and output dimensions respectively (See Report 
+  section below).
 
 - `priors`: The class priors for classification. As inferred from training target `y`, if
-    not user-specified. A UnivariateFinite object with levels consistent with `levels(y)`.
+  not user-specified. A `UnivariateFinite` object with levels consistent with `levels(y)`.
 
 # Report
 
@@ -950,18 +950,18 @@ The fields of `report(mach)` are:
 - `mean`: The overall mean of the training data.
 
 - `nclasses`: The number of classes directly observed in the training data (which can be
-    less than the total number of classes in the class pool).
+  less than the total number of classes in the class pool).
 
 `class_means`: The class-specific means of the training data. A matrix of size 
-    `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
-    `classes` (See fitted params section above).
+  `(indim, nclasses)` with the ith column being the class-mean of the ith class in 
+  `classes` (See fitted params section above).
 
 - `class_weights`: The weights (class counts) of each class. A vector of length `nclasses` 
-    with the ith element being the class weight of the ith class in `classes`. (See 
-    fitted params section above.)
+  with the ith element being the class weight of the ith class in `classes`. (See 
+  fitted params section above.)
 
 - `explained_variance_ratio`: The ratio of explained variance to total variance. Each 
-    dimension corresponds to an eigenvalue.
+  dimension corresponds to an eigenvalue.
 
 # Examples
 

--- a/src/models/discriminant_analysis.jl
+++ b/src/models/discriminant_analysis.jl
@@ -20,11 +20,11 @@ const ERR_LONE_TARGET_CLASS = ArgumentError(
 )
 
 function _check_lda_data(model, X, y)
-    pool = MMI.classes(y[1]) # Class list containing entries in pool of y.
-    classes_seen = unique(y) # Class list of actual entries in seen in y.
-    nc = length(classes_seen) # Number of classes in pool of y.
+    pool = MMI.classes(y[1]) # Class list containing entries in pool of `y`.
+    classes_seen = unique(y) # Class list of actual entries in seen in `y`.
+    nc = length(classes_seen) # Number of actual classes seen in `y`.
 
-    Xm_t = _matrix_transpose(model, X) # Now p x n matrix
+    Xm_t = _matrix_transpose(model, X) # Now `p x n` matrix
     p, n = size(Xm_t)
 
     # Check to make sure we have more than one class in training sample.

--- a/src/models/linear_models.jl
+++ b/src/models/linear_models.jl
@@ -184,7 +184,8 @@ metadata_model(
 $(MMI.doc_header(LinearRegressor))
 
 `LinearRegressor` assumes the target is a `Continuous` variable and trains a linear
-prediction function using the least squares algorithm. Options exist to specify a bias term.
+prediction function using the least squares algorithm. Options exist to specify a bias 
+term.
 
 # Training data
 
@@ -194,11 +195,11 @@ In MLJ or MLJBase, bind an instance `model` to data with
 
 Here:
 
-- `X` is any table of input features (eg, a `DataFrame`) whose columns
-are of scitype `Continuous`; check the column scitypes with `schema(X)`.
+- `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype 
+    `Continuous`; check the column scitypes with `schema(X)`.
 
-- `y` is the target, which can be any `AbstractVector` whose element
-  scitype is `Continuous`; check the scitype with `scitype(y)`.
+- `y` is the target, which can be any `AbstractVector` whose element scitype is 
+    `Continuous`; check the scitype with `scitype(y)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -208,14 +209,15 @@ Train the machine using `fit!(mach, rows=...)`.
 
 # Operations
 
-- `predict(mach, Xnew)`: Return predictions of the target given new
-  features `Xnew`, which should have the same scitype as `X` above.
+- `predict(mach, Xnew)`: Return predictions of the target given new features `Xnew`, which 
+    should have the same scitype as `X` above.
 
 # Fitted parameters
 
 The fields of `fitted_params(mach)` are:
 
 - `coefficients`: The linear coefficients determined by the model.
+
 - `intercept`: The intercept determined by the model.
 
 # Examples
@@ -255,11 +257,11 @@ In MLJ or MLJBase, bind an instance `model` to data with
 
 Here:
 
-- `X` is any table of input features (eg, a `DataFrame`) whose columns
-are of scitype `Continuous`; check column scitypes with `schema(X)`.
+- `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype 
+    `Continuous`; check column scitypes with `schema(X)`.
 
-- `y` is the target, which can be any table of responses whose element
-  scitype is `Continuous`; check the scitype with `scitype(y)`.
+- `y` is the target, which can be any table of responses whose element scitype is 
+    `Continuous`; check the scitype with `scitype(y)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -269,8 +271,8 @@ Train the machine using `fit!(mach, rows=...)`.
 
 # Operations
 
-- `predict(mach, Xnew)`: Return predictions of the target given new
-  features `Xnew`, which should have the same scitype as `X` above.
+- `predict(mach, Xnew)`: Return predictions of the target given new features `Xnew`, 
+    which should have the same scitype as `X` above.
 
 # Fitted parameters
 
@@ -319,27 +321,26 @@ In MLJ or MLJBase, bind an instance `model` to data with
 
 Here:
 
-- `X` is any table of input features (eg, a `DataFrame`) whose columns
-are of scitype `Continuous`; check column scitypes with `schema(X)`.
+- `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype 
+    `Continuous`; check column scitypes with `schema(X)`.
 
-- `y` is the target, which can be any `AbstractVector` whose element
-  scitype is `Continuous`; check the scitype with `scitype(y)`
+- `y` is the target, which can be any `AbstractVector` whose element scitype is 
+    `Continuous`; check the scitype with `scitype(y)`
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
-- `lambda=1.0`: Is the non-negative parameter for the
-  regularization strength. If lambda is 0, ridge regression is equivalent
-  to linear least squares regression, and as lambda approaches infinity,
-  all the linear coefficients approach 0.
+- `lambda=1.0`: Is the non-negative parameter for the regularization strength. If lambda 
+    is 0, ridge regression is equivalent to linear least squares regression, and as lambda 
+    approaches infinity, all the linear coefficients approach 0.
 
 - `bias=true`: Include the bias term if true, otherwise fit without bias term.
 
 # Operations
 
-- `predict(mach, Xnew)`: Return predictions of the target given new
-  features `Xnew`, which should have the same scitype as `X` above.
+- `predict(mach, Xnew)`: Return predictions of the target given new features `Xnew`, which 
+    should have the same scitype as `X` above.
 
 # Fitted parameters
 
@@ -387,27 +388,26 @@ In MLJ or MLJBase, bind an instance `model` to data with
 
 Here:
 
-- `X` is any table of input features (eg, a `DataFrame`) whose columns
-are of scitype `Continuous`; check column scitypes with `schema(X)`.
+- `X` is any table of input features (eg, a `DataFrame`) whose columns are of scitype 
+    `Continuous`; check column scitypes with `schema(X)`.
 
-- `y` is the target, which can be any table of responses whose element
-  scitype is `Continuous`; check the scitype with `scitype(y)`.
+- `y` is the target, which can be any table of responses whose element scitype is 
+    `Continuous`; check the scitype with `scitype(y)`.
 
 Train the machine using `fit!(mach, rows=...)`.
 
 # Hyper-parameters
 
-- `lambda=1.0`: Is the non-negative parameter for the
-  regularization strength. If lambda is 0, ridge regression is equivalent
-  to linear least squares regression, and as lambda approaches infinity,
-  all the linear coefficients approach 0.
+- `lambda=1.0`: Is the non-negative parameter for the regularization strength. If lambda 
+    is 0, ridge regression is equivalent to linear least squares regression, and as lambda 
+    approaches infinity, all the linear coefficients approach 0.
 
 - `bias=true`: Include the bias term if true, otherwise fit without bias term.
 
 # Operations
 
-- `predict(mach, Xnew)`: Return predictions of the target given new
-  features `Xnew`, which should have the same scitype as `X` above.
+- `predict(mach, Xnew)`: Return predictions of the target given new features `Xnew`, which 
+    should have the same scitype as `X` above.
 
 # Fitted parameters
 


### PR DESCRIPTION
supersedes #45 and #49. 
This PR also
1. Adds more tests. 
2. Makes improvements to model doc strings
3. Allow users to pass `Dict` and `UnivariateFinite` objects to `priors` kwarg of `BayesianLDA` and `BayesianSubspaceLDA` models.
4. Pass adjoints to core fit method.

cc. @ablaom 