### PR TITLE
report loadings for PCA models

### DIFF
--- a/src/models/decomposition_models.jl
+++ b/src/models/decomposition_models.jl
@@ -32,7 +32,10 @@ function MMI.fit(model::PCA, verbosity::Int, X)
         tresidualvar=MS.tresidualvar(fitresult),
         tvar=MS.var(fitresult),
         mean=copy(MS.mean(fitresult)),
-        principalvars=copy(MS.principalvars(fitresult))
+        principalvars=copy(MS.principalvars(fitresult)),
+        # no need to copy here as a new copy is created 
+        # for each function call
+        loadings = MS.loadings(fitresult) 
     )
     return fitresult, cache, report
 end
@@ -175,7 +178,7 @@ function MMI.fit(model::PPCA, verbosity::Int, X)
         outdim=size(fitresult)[2],
         tvar=MS.var(fitresult),
         mean=copy(MS.mean(fitresult)),
-        loadings=MS.loadings(fitresult)
+        loadings = copy(MS.loadings(fitresult))
     )
     return fitresult, cache, report
 end
@@ -362,7 +365,12 @@ The fields of `report(mach)` are:
 
 - `mean`: The mean of the untransformed training data, of length `indim`.
 
-- `principalvars`: The variance of the principal components.
+- `principalvars`: The variance of the principal components. An AbstractVector of 
+  length `outdim`
+
+- `loadings`: The models loadings, weights for each variable used when calculating 
+  principal components. A matrix of size (`indim`, `outdim`) where `indim` and 
+  `outdim` are as defined above.
 
 # Examples
 
@@ -669,7 +677,8 @@ The fields of `report(mach)` are:
 
 - `mean`: The mean of the untransformed training data, of length `indim`.
 
-- `loadings`: The factor loadings.
+- `loadings`: The factor loadings. A matrix of size (`indim`, `outdim`) where 
+  `indim` and `outdim` are as defined above.
 
 # Examples
 
@@ -765,8 +774,8 @@ The fields of `report(mach)` are:
 
 - `tvat`: The variance of the components.
 
-- `loadings`: The models loadings, weights for each variable used when calculating 
-  principal components.
+- `loadings`: The model's loadings matrix. A matrix of size (`indim`, `outdim`) where 
+  `indim` and `outdim` as as defined above.
 
 # Examples
 

--- a/test/models/decomposition_models.jl
+++ b/test/models/decomposition_models.jl
@@ -11,7 +11,17 @@ X, y = @load_crabs
     )
     # MLJ PCA
     pca_mlj = PCA(variance_ratio=variance_ratio)
-    test_composition_model(pca_ms, pca_mlj, X, X_array)
+    _, _, report = test_decomposition_model(pca_ms, pca_mlj, X, X_array)
+    
+    # Test report
+    @test report.indim == size(pca_ms)[1]
+    @test report.outdim == size(pca_ms)[2]
+    @test report.tprincipalvar == MS.tprincipalvar(pca_ms)
+    @test report.tresidualvar == MS.tresidualvar(pca_ms)
+    @test report.tvar == MS.var(pca_ms)
+    @test report.mean == MS.mean(pca_ms)
+    @test report.principalvars == MS.principalvars(pca_ms)
+    @test report.loadings == MS.loadings(pca_ms)
 end
 
 @testset "KernelPCA" begin
@@ -23,7 +33,12 @@ end
     )
     # MLJ KernelPCA
     kpca_mlj = KernelPCA()
-    test_composition_model(kpca_ms, kpca_mlj, X, X_array)
+    _, _, report = test_decomposition_model(kpca_ms, kpca_mlj, X, X_array)
+    
+    # Test report
+    @test report.indim == size(kpca_ms)[1]
+    @test report.outdim == size(kpca_ms)[2]
+    @test report.principalvars == MS.eigvals(kpca_ms)
 end
 
 @testset "ICA" begin
@@ -47,7 +62,14 @@ end
         outdim=outdim,
         tol=tolerance,
         winit=randn(rng, eltype(X_array), size(X_array, 2), outdim))
-    test_composition_model(ica_ms, ica_mlj, X, X_array, test_inverse=false)
+    _, _, report = test_decomposition_model(
+        ica_ms, ica_mlj, X, X_array, test_inverse=false
+    )
+
+    # Test report
+    @test report.indim == size(ica_ms)[1]
+    @test report.outdim == size(ica_ms)[2]
+    @test report.mean == MS.mean(ica_ms)
 end
 
 @testset "ICA2" begin
@@ -73,7 +95,10 @@ end
         tol=tolerance,
         fun=:gaus,
         winit=randn(rng, eltype(X_array), size(X_array, 2), outdim))
-    test_composition_model(ica_ms, ica_mlj, X, X_array, test_inverse=false)
+    test_decomposition_model(
+        ica_ms, ica_mlj, X, X_array;
+        test_inverse=false
+    )
 end
 
 @testset "PPCA" begin
@@ -87,7 +112,14 @@ end
     )
     # MLJ PPCA
     ppca_mlj = PPCA(;tol=tolerance)
-    test_composition_model(ppca_ms, ppca_mlj, X, X_array)
+    _, _, report = test_decomposition_model(ppca_ms, ppca_mlj, X, X_array)
+    
+    # Test report
+    @test report.indim == size(ppca_ms)[1]
+    @test report.outdim == size(ppca_ms)[2]
+    @test report.tvar == MS.var(ppca_ms)
+    @test report.mean == MS.mean(ppca_ms)
+    @test report.loadings == MS.loadings(ppca_ms)
 end
 
 @testset "FactorAnalysis" begin
@@ -102,6 +134,16 @@ end
         η=eta
     )
     factoranalysis_mlj = FactorAnalysis(;tol=tolerance, eta=eta)
-    test_composition_model(factoranalysis_ms, factoranalysis_mlj, X, X_array)
+    _, _, report = test_decomposition_model(
+        factoranalysis_ms, factoranalysis_mlj, X, X_array
+    )
+
+    # Test report
+    @test report.indim == size(factoranalysis_ms)[1]
+    @test report.outdim == size(factoranalysis_ms)[2]
+    @test report.variance == MS.var(factoranalysis_ms)
+    @test report.covariance_matrix == MS.cov(factoranalysis_ms)
+    @test report.mean == MS.mean(factoranalysis_ms)
+    @test report.loadings == MS.loadings(factoranalysis_ms)
 end
 

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -19,12 +19,11 @@ function test_regression(model, X, y)
     return yhat, fr
 end
 
-function test_composition_model(ms_model, mlj_model, X, X_array ; test_inverse=true)
-    mlj_model_type = typeof(mlj_model)
+function test_decomposition_model(ms_model, mlj_model, X, X_array ; test_inverse=true)
     Xtr_ms = permutedims(
         MultivariateStats.predict(ms_model, permutedims(X_array))
     )
-    fitresult, _, _ = fit(mlj_model, 1, X)
+    fitresult, cache, report = fit(mlj_model, 1, X)
     Xtr_mlj_table = transform(mlj_model, fitresult, X)
     Xtr_mlj = matrix(Xtr_mlj_table)
     # Compare MLJ and MultivariateStats transformed matrices
@@ -43,4 +42,7 @@ function test_composition_model(ms_model, mlj_model, X, X_array ; test_inverse=t
     # smoke test for issue #42
     fp = MLJBase.fitted_params(mlj_model, fitresult)
     :projection in keys(fp)
+    
+    return fitresult, cache, report
 end
+


### PR DESCRIPTION
closes #53 

```julia
julia> using MLJMultivariateStatsInterface, MLJBase

julia> mach = fit!(machine(PCA(), MLJ.table(rand(4,4))))
[ Info: Training machine(PCA(maxoutdim = 0, …), …).
trained Machine; caches model-specific representations of data
  model: PCA(maxoutdim = 0, …)
  args:
    1:  Source @693 ⏎ Table{AbstractVector{Continuous}}


julia> report(mach).loadings
4×3 Matrix{Float64}:
 -0.259415   -0.120612  -0.0649511
  0.371288   -0.079516  -0.0585722
  0.0619987   0.101208   0.0369897
  0.0359145  -0.223864   0.0725215
```